### PR TITLE
feat: 新增Strm日志按钮及关键词过滤功能

### DIFF
--- a/emby-actor-ui/src/MainLayout.vue
+++ b/emby-actor-ui/src/MainLayout.vue
@@ -91,6 +91,14 @@
               </n-tooltip>
               <n-tooltip>
                 <template #trigger>
+                  <n-button @click="isStrmLogVisible = true" circle>
+                    <template #icon><n-icon :component="RecordsIcon" /></template>
+                  </n-button>
+                </template>
+                Strm日志
+              </n-tooltip>
+              <n-tooltip>
+                <template #trigger>
                   <n-button @click="isHistoryLogVisible = true" circle>
                     <template #icon><n-icon :component="ArchiveOutline" /></template>
                   </n-button>
@@ -210,6 +218,11 @@
 
     <!-- 历史日志模态框 -->
     <LogViewer v-model:show="isHistoryLogVisible" />
+
+    <!-- Strm日志模态框 -->
+    <n-modal v-model:show="isStrmLogVisible" preset="card" style="width: 95%; max-width: 900px;" title="Strm日志" class="modal-card-lite">
+      <n-log ref="strmLogRef" :log="strmLogContent" trim class="log-panel" style="height: 60vh; font-size: 13px; line-height: 1.6;"/>
+    </n-modal>
 
     <!-- ★★★ 自定义菜单编辑器模态框 ★★★ -->
     <n-modal v-model:show="isMenuEditorVisible" preset="card" style="width: 95%; max-width: 650px;" title="自定义侧边栏菜单 (全局生效)">
@@ -388,8 +401,10 @@ const activeMenuKey = computed(() => route.name);
 const appVersion = ref(__APP_VERSION__);
 
 const isRealtimeLogVisible = ref(false);
+const isStrmLogVisible = ref(false);
 const isHistoryLogVisible = ref(false);
 const logRef = ref(null);
+const strmLogRef = ref(null);
 
 watch(() => route.path, () => {
   if (isMobile.value) {
@@ -409,11 +424,29 @@ const themeOptions = [
 const renderIcon = (iconComponent) => () => h(NIcon, null, { default: () => h(iconComponent) });
 
 const logContent = computed(() => props.taskStatus?.logs?.join('\n') || '等待任务日志...');
+const strmKeywords = [
+  '成功获取直链',
+  '成功通过 115 API 实时获取到 SHA1',
+  '成功生成媒体信息',
+  '媒体信息缓存'
+];
+const strmLogContent = computed(() => {
+  const logs = props.taskStatus?.logs || [];
+  const filteredLogs = logs.filter(line => strmKeywords.some(keyword => line.includes(keyword)));
+  return filteredLogs.length > 0 ? filteredLogs.join('\n') : '暂无Strm相关日志...';
+});
 
 watch([() => props.taskStatus?.logs, isRealtimeLogVisible], async ([, isVisible]) => {
   if (isVisible) {
     await nextTick();
     logRef.value?.scrollTo({ position: 'bottom', slient: true });
+  }
+}, { deep: true });
+
+watch([() => props.taskStatus?.logs, isStrmLogVisible], async ([, isVisible]) => {
+  if (isVisible) {
+    await nextTick();
+    strmLogRef.value?.scrollTo({ position: 'bottom', slient: true });
   }
 }, { deep: true });
 

--- a/monitor_service.py
+++ b/monitor_service.py
@@ -445,10 +445,13 @@ class MonitorService:
 
     def stop(self):
         if self.observer:
-            logger.info("  ➜ 正在停止实时监控服务...")
-            self.observer.stop()
-            self.observer.join()
-            logger.info("  ➜ 实时监控服务已停止。")
+            try:
+                self.observer.stop()
+                self.observer.join(timeout=5)
+            except RuntimeError:
+                pass
+            finally:
+                logger.info("  ➜ 实时监控服务已停止。")
 
 def pause_queue_processing():
     """暂停监控队列处理 (进入蓄水池模式)"""


### PR DESCRIPTION
## Summary

- **新增Strm日志按钮**：位于实时日志与历史日志之间，点击弹出独立模态框查看 Strm 相关日志
- **过滤关键词列表**：自动过滤包含以下关键词的日志行，方便快速定位 Strm 处理进度
  - `成功获取直链`
  - `成功通过 115 API 实时获取到 SHA1`
  - `成功生成媒体信息`
  - `媒体信息缓存`
- **修复 `monitor_service.py`**：`stop()` 方法中 observer 停止时的 `RuntimeError` 异常处理

## 不影响原有功能

- 实时日志、历史日志功能完全不变
- 仅新增独立的 Strm 日志视图，零侵入

## 按钮位置说明

按钮位置：顶部工具栏 — **实时日志** `[Strm日志]` **历史日志**