### PR TITLE
Enhance p115 media recognition with deterministic pre-parse rules

### DIFF
--- a/handler/p115_service.py
+++ b/handler/p115_service.py
@@ -69,6 +69,7 @@ _TMDB_METADATA_CACHE = LimitedCache(maxsize=1000)
 _TMDB_SEARCH_CACHE = LimitedCache(maxsize=1000)
 _AI_PARSE_CACHE = LimitedCache(maxsize=1000)
 _MP_PARSE_CACHE = LimitedCache(maxsize=1000)
+_RULE_PARSE_CACHE = LimitedCache(maxsize=2000)
 
 # 全局直链缓存池，供反向代理和Web路由共享 
 _DIRECT_URL_CACHE = LimitedCache(maxsize=2000)
@@ -76,6 +77,28 @@ _DIRECT_URL_CACHE = LimitedCache(maxsize=2000)
 # 全局目录缓存池
 _GLOBAL_DIR_CACHE = LimitedCache(maxsize=5000)
 _GLOBAL_DIR_LOCK = threading.Lock()
+
+_NOISE_TOKEN_PATTERNS = [
+    r'(?i)\b(?:WEB[-_. ]?DL|WEB[-_. ]?RIP|BLU[-_. ]?RAY|BDRIP|BRRIP|REMUX|DVDRIP|HDTV|UHD)\b',
+    r'(?i)\b(?:HDR10\+?|HDR|DV|DOVI|DOLBY[.\s_-]*VISION|HLG)\b',
+    r'(?i)\b(?:HEVC|AVC|X265|X264|H265|H264|10BIT|8BIT|AAC\d?(?:\.\d)?|DDP\d?(?:\.\d)?|DD\d?(?:\.\d)?|TRUEHD|ATMOS|DTS(?:[-_. ]?HD)?|FLAC)\b',
+    r'(?i)\b(?:2160P|1080P|720P|576P|480P|4K)\b',
+    r'(?i)\b(?:NF|NETFLIX|AMZN|AMAZON|DSNP|DISNEY|HMAX|MAX|ATVP|APPLE|IQIYI|YOUKU|WEB)\b',
+    r'(?i)\b(?:MULTI|DUAL[-_. ]?AUDIO|DUAL|PROPER|REPACK|READNFO|EXTENDED|UNCUT|COMPLETE|FINAL)\b',
+    r'(?i)\b(?:CHS|CHT|ENG|JPN|KOR|GB|BIG5|简中|繁中|中字|双语|国粤|内封|外挂|特效字幕)\b',
+    r'(?i)\b(?:AAC2\.0|AAC5\.1|DDP5\.1|DD5\.1|DTS5\.1|TRUEHD7\.1|ATMOS7\.1)\b',
+    r'(?i)\b(?:CAM|TS|TC|R5)\b',
+]
+
+_DATE_EPISODE_PATTERNS = [
+    re.compile(r'(?<!\d)(20\d{2})[.\-_ ](0[1-9]|1[0-2])[.\-_ ]([0-3]\d)(?!\d)'),
+    re.compile(r'(?<!\d)(20\d{2})(0[1-9]|1[0-2])([0-3]\d)(?!\d)'),
+]
+
+_SPECIAL_FLAG_PATTERNS = [
+    re.compile(r'(?i)(?:^|[ \.\-_/\[(])(?:specials?|sp|ova|oad|oads|extra(?:s)?|ncop|nced)(?:$|[ \.\-_/)\]])'),
+    re.compile(r'(?:特别篇|特別篇|番外(?:篇)?|外传|外傳|总集篇|總集篇|OVA|OAD)', re.IGNORECASE),
+]
 
 def get_115_tokens():
     """唯一真理：只从独立数据库获取 Token 和 Cookie"""
@@ -3275,6 +3298,14 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
 
     def _rename_file_node(self, file_node, new_base_name, year=None, is_tv=False, original_title=None, pre_fetched_mediainfo=None, local_pre_fetched_mediainfo=None, silent_log=False):
         original_name = file_node.get('fn') or file_node.get('n') or file_node.get('file_name', '')
+        rel_path = file_node.get('rel_path', '')
+        rule_result = _build_rule_parse_result(
+            filename=original_name,
+            main_dir_name=os.path.basename(rel_path) if rel_path else None,
+            has_season_subdirs=False,
+            forced_media_type='tv' if is_tv else 'movie',
+            is_folder=False,
+        )
         
         # ★ 修复 1：无后缀文件的提前返回，补齐为 8 个返回值
         if '.' not in original_name: 
@@ -3372,7 +3403,6 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                 )
 
         if is_tv and (season_num is None or episode_num is None):
-            rel_path = file_node.get('rel_path', '')
 
             # 0. ★ 先跑用户自定义规则，命中即优先使用
             custom_season, custom_episode, custom_rule_name = self._parse_season_episode_by_custom_regex(
@@ -3388,6 +3418,19 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
             if custom_rule_name and not silent_log:
                 logger.info(
                     f"  ➜ [自定义季集号识别] 命中规则 '{custom_rule_name}' -> "
+                    f"S{int(season_num if season_num is not None else 1):02d}E{int(episode_num if episode_num is not None else 0):02d} | {original_name}"
+                )
+
+            if rule_result.get('season_number') is not None and season_num is None:
+                season_num = int(rule_result.get('season_number'))
+            if rule_result.get('episode_number') is not None and episode_num is None:
+                episode_num = int(rule_result.get('episode_number'))
+            if (
+                (rule_result.get('season_number') is not None or rule_result.get('episode_number') is not None)
+                and not silent_log
+            ):
+                logger.info(
+                    f"  ➜ [规则预解析季集] 命中 evidence={','.join(rule_result.get('evidence') or []) or 'rule'} -> "
                     f"S{int(season_num if season_num is not None else 1):02d}E{int(episode_num if episode_num is not None else 0):02d} | {original_name}"
                 )
 
@@ -3453,6 +3496,12 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
             # 4. 终极兜底
             if season_num is None:
                 season_num = 1
+
+        if is_tv and rule_result.get('is_special') and season_num is None:
+            season_num = 0
+
+        if is_tv and rule_result.get('is_special') and season_num == 1 and episode_num is None:
+            season_num = 0
 
         # ★★★ 动漫绝对集数转季号逻辑 (解决海贼王 S01E1158 的问题) ★★★
         if is_tv and episode_num is not None and episode_num > 30:
@@ -5434,6 +5483,275 @@ def _get_raw_ffprobe_identity_by_sha1(sha1):
         return None
 
 
+def _normalize_rule_media_type(value):
+    text = str(value or '').strip().lower()
+    if text in ['movie', 'movies', 'film', '电影']:
+        return 'movie'
+    if text in ['tv', 'series', 'episode', 'season', 'show', '电视剧', '剧集', '番剧', '动漫']:
+        return 'tv'
+    return None
+
+
+def _parse_rule_cn_number(value):
+    text = str(value or '').strip()
+    if not text:
+        return None
+    if text.isdigit():
+        return int(text)
+
+    digit_map = {'零': 0, '一': 1, '二': 2, '两': 2, '三': 3, '四': 4, '五': 5, '六': 6, '七': 7, '八': 8, '九': 9}
+    unit_map = {'十': 10, '百': 100}
+    total = 0
+    current = 0
+    for ch in text:
+        if ch in digit_map:
+            current = digit_map[ch]
+        elif ch in unit_map:
+            unit = unit_map[ch]
+            if current == 0:
+                current = 1
+            total += current * unit
+            current = 0
+    total += current
+    return total or None
+
+
+def _clean_rule_title(text):
+    if not text:
+        return ''
+
+    value = str(text).replace('\\', '/')
+    value = os.path.basename(value.strip())
+    value = os.path.splitext(value)[0]
+
+    for pattern in _NOISE_TOKEN_PATTERNS:
+        value = re.sub(pattern, ' ', value)
+
+    value = re.sub(r'(?i)\b(?:s\d{1,4}[ .\-_]*e\d{1,4}|season[ .\-_]*\d{1,4}|ep(?:isode)?[ .\-_]*\d{1,4}|第[一二三四五六七八九十百零\d]+[季集话話回])\b', ' ', value)
+    value = re.sub(r'(?i)\b(?:part|pt|cd)[ .\-_]*\d{1,2}\b', ' ', value)
+    value = re.sub(r'(?i)\b(?:tmdb|tmdbid)[=\-_ ]*\d+\b', ' ', value)
+    value = re.sub(r'(?<!\d)(?:19|20)\d{2}(?!\d)', ' ', value)
+    value = re.sub(r'(?i)\b(?:specials?|ova|oad|sp|extra(?:s)?|collection|complete)\b', ' ', value)
+    value = re.sub(r'[\[\]\(\)\{\}]', ' ', value)
+    value = re.sub(r'[._]+', ' ', value)
+    value = re.sub(r'\s+', ' ', value).strip(' -_./')
+    return value.strip()
+
+
+def _extract_rule_year(text):
+    if not text:
+        return None
+    matches = list(re.finditer(r'(?<!\d)((?:19|20)\d{2})(?!\d)', str(text)))
+    if not matches:
+        return None
+    try:
+        return int(matches[-1].group(1))
+    except Exception:
+        return None
+
+
+def _rule_detect_special(text):
+    if not text:
+        return False
+    for pattern in _SPECIAL_FLAG_PATTERNS:
+        if pattern.search(str(text)):
+            return True
+    return False
+
+
+def _rule_extract_tmdb_id(*texts):
+    tmdb_regex = re.compile(r'(?i)(?:tmdb|tmdbid)[=\-_ ]*(\d{2,10})')
+    for text in texts:
+        if not text:
+            continue
+        match = tmdb_regex.search(str(text))
+        if match:
+            return match.group(1)
+    return None
+
+
+def _rule_extract_date_episode(text):
+    if not text:
+        return None
+    for pattern in _DATE_EPISODE_PATTERNS:
+        match = pattern.search(str(text))
+        if match:
+            year, month, day = match.groups()
+            try:
+                return int(f"{year}{month}{day}")
+            except Exception:
+                return None
+    return None
+
+
+def _rule_extract_season_episode_from_text(text):
+    if not text:
+        return None, None, []
+
+    evidence = []
+    normalized = str(text).replace('\\', '/')
+    lower_text = normalized.lower()
+
+    match = re.search(r'(?i)(?:^|[ \.\-_/\[(])s(\d{1,4})[ \.\-_]*[eEpP](\d{1,4})(?:$|[ \.\-_/)\]])', normalized)
+    if match:
+        evidence.append('sxe')
+        return int(match.group(1)), int(match.group(2)), evidence
+
+    match = re.search(r'(?i)(?:^|[ \.\-_/\[(])season[ \.\-_]*(\d{1,4})(?:$|[ \.\-_/)\]])', normalized)
+    season_num = int(match.group(1)) if match else None
+    if match:
+        evidence.append('season_word')
+
+    match = re.search(r'第\s*([一二三四五六七八九十百零\d]+)\s*季', normalized)
+    if match and season_num is None:
+        cn_number = _parse_rule_cn_number(match.group(1))
+        if cn_number is not None:
+            season_num = int(cn_number)
+            evidence.append('season_zh')
+
+    match = re.search(r'(?i)(?:^|[ \.\-_/\[(])(?:ep|episode)[ \.\-_]*(\d{1,4})(?:$|[ \.\-_/)\]])', normalized)
+    episode_num = int(match.group(1)) if match else None
+    if match:
+        evidence.append('episode_word')
+
+    match = re.search(r'(?i)(?:^|[ \.\-_/\[(])e(\d{1,4})(?:$|[ \.\-_/)\]])', normalized)
+    if match and episode_num is None:
+        episode_num = int(match.group(1))
+        evidence.append('episode_e')
+
+    match = re.search(r'第\s*([一二三四五六七八九十百零\d]+)\s*[集话話回]', normalized)
+    if match and episode_num is None:
+        cn_number = _parse_rule_cn_number(match.group(1))
+        if cn_number is not None:
+            episode_num = int(cn_number)
+            evidence.append('episode_zh')
+
+    if episode_num is None:
+        date_ep = _rule_extract_date_episode(normalized)
+        if date_ep is not None:
+            episode_num = date_ep
+            evidence.append('episode_date')
+
+    if _rule_detect_special(normalized):
+        if season_num is None:
+            season_num = 0
+        evidence.append('special')
+
+    if episode_num is None:
+        match = re.search(r'(?i)(?:^|[ \.\-_/\[(])(?:sp|ova|oad)(\d{1,4})(?:$|[ \.\-_/)\]])', normalized)
+        if match:
+            episode_num = int(match.group(1))
+            evidence.extend(['special', 'episode_special_code'])
+
+    if season_num is None and episode_num is not None and any(flag in lower_text for flag in ['ep', 'episode', '第', '话', '話', '回']):
+        season_num = 1
+
+    return season_num, episode_num, evidence
+
+
+def _build_rule_parse_result(filename, main_dir_name=None, has_season_subdirs=False, forced_media_type=None, is_folder=False):
+    cache_key = json.dumps({
+        'filename': filename or '',
+        'main_dir_name': main_dir_name or '',
+        'has_season_subdirs': bool(has_season_subdirs),
+        'forced_media_type': forced_media_type or '',
+        'is_folder': bool(is_folder),
+    }, ensure_ascii=False, sort_keys=True)
+    if cache_key in _RULE_PARSE_CACHE:
+        return _RULE_PARSE_CACHE[cache_key]
+
+    source_texts = [str(x) for x in [filename, main_dir_name] if x]
+    combined_text = ' / '.join(source_texts)
+    result = {
+        'tmdb_id': None,
+        'media_type': _normalize_rule_media_type(forced_media_type),
+        'title': None,
+        'year': None,
+        'season_number': None,
+        'episode_number': None,
+        'is_special': False,
+        'confidence': 'low',
+        'evidence': [],
+        'source': 'rules',
+    }
+
+    explicit_tmdb_id = _rule_extract_tmdb_id(filename, main_dir_name)
+    if explicit_tmdb_id:
+        result['tmdb_id'] = explicit_tmdb_id
+        result['confidence'] = 'high'
+        result['evidence'].append('explicit_tmdb')
+
+    season_num = None
+    episode_num = None
+    season_evidence = []
+    for text in source_texts:
+        s_val, e_val, evi = _rule_extract_season_episode_from_text(text)
+        if season_num is None and s_val is not None:
+            season_num = s_val
+        if episode_num is None and e_val is not None:
+            episode_num = e_val
+        season_evidence.extend(evi)
+        if season_num is not None and episode_num is not None and 'special' not in season_evidence:
+            break
+
+    if has_season_subdirs and season_num is None:
+        season_num = 1
+        season_evidence.append('season_subdir')
+
+    result['season_number'] = season_num
+    result['episode_number'] = episode_num
+    result['is_special'] = 'special' in season_evidence or _rule_detect_special(combined_text)
+    result['evidence'].extend([e for e in season_evidence if e not in result['evidence']])
+
+    title_candidates = []
+    generic_dir = bool(main_dir_name and re.search(r'(?i)\b(collection|合集|系列|pack|misc|unknown)\b', str(main_dir_name)))
+    if filename:
+        title_candidates.append(filename)
+    if main_dir_name and str(main_dir_name).strip() and str(main_dir_name) != str(filename) and not generic_dir:
+        title_candidates.insert(0, main_dir_name)
+
+    for candidate in title_candidates:
+        clean_title = _clean_rule_title(candidate)
+        if clean_title:
+            result['title'] = clean_title
+            break
+
+    if not result['title'] and main_dir_name:
+        result['title'] = _clean_rule_title(main_dir_name)
+
+    for candidate in title_candidates:
+        year_val = _extract_rule_year(candidate)
+        if year_val:
+            result['year'] = year_val
+            result['evidence'].append('year')
+            break
+
+    if result['media_type'] is None:
+        if result['season_number'] is not None or has_season_subdirs:
+            result['media_type'] = 'tv'
+            result['evidence'].append('tv_structure')
+        elif result['episode_number'] is not None and result['season_number'] is not None:
+            result['media_type'] = 'tv'
+            result['evidence'].append('tv_structure')
+        elif result['tmdb_id']:
+            result['media_type'] = 'movie'
+        elif result['title'] and result['year']:
+            result['media_type'] = 'movie'
+
+    if result['is_special'] and result['season_number'] is None:
+        result['season_number'] = 0
+
+    if result['tmdb_id']:
+        result['confidence'] = 'high'
+    elif result['title'] and (result['year'] or result['media_type'] or result['episode_number'] is not None):
+        result['confidence'] = 'medium'
+    elif result['title']:
+        result['confidence'] = 'low'
+
+    _RULE_PARSE_CACHE[cache_key] = result
+    return result
+
+
 def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=False, forced_media_type=None, ai_translator=None, use_ai=False, is_folder=False, sha1=None, raw_ffprobe_json=None):
     """
     【绝对正确版】识别逻辑：
@@ -5448,6 +5766,13 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
     api_key = config_manager.APP_CONFIG.get(constants.CONFIG_OPTION_TMDB_API_KEY)
     
     is_same_name = (main_dir_name == filename)
+    rule_result = _build_rule_parse_result(
+        filename=filename,
+        main_dir_name=main_dir_name,
+        has_season_subdirs=has_season_subdirs,
+        forced_media_type=forced_media_type,
+        is_folder=is_folder,
+    )
 
     # =================================================================
     # ★ 第一步：铁腕判定媒体类型 (Movie or TV)
@@ -5455,10 +5780,25 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
     if forced_media_type:
         media_type = forced_media_type
     else:
-        # 将主目录名和文件名拼在一起，寻找剧集特征
-        combined_text = f"{main_dir_name or ''} {filename}"
-        if has_season_subdirs or re.search(r'(?:^|[ \.\-\_\[\(])(?:s|S)\d{1,4}[ \.\-]*(?:e|E|p|P)\d{1,4}\b|(?:^|[ \.\-\_\[\(])(?:ep|episode)[ \.\-]*\d{1,4}\b|(?:^|[ \.\-\_\[\(])e\d{1,4}\b|第[一二三四五六七八九十\d]+季|Season', combined_text, re.IGNORECASE):
-            media_type = 'tv'
+        if rule_result.get('media_type'):
+            media_type = rule_result.get('media_type')
+        else:
+            # 将主目录名和文件名拼在一起，寻找剧集特征
+            combined_text = f"{main_dir_name or ''} {filename}"
+            if has_season_subdirs or re.search(r'(?:^|[ \.\-\_\[\(])(?:s|S)\d{1,4}[ \.\-]*(?:e|E|p|P)\d{1,4}\b|(?:^|[ \.\-\_\[\(])(?:ep|episode)[ \.\-]*\d{1,4}\b|(?:^|[ \.\-\_\[\(])e\d{1,4}\b|第[一二三四五六七八九十\d]+季|Season', combined_text, re.IGNORECASE):
+                media_type = 'tv'
+
+    if rule_result.get('title'):
+        title = rule_result.get('title')
+
+    if rule_result.get('confidence') in ('medium', 'high') and rule_result.get('title'):
+        evidence_text = ','.join(rule_result.get('evidence') or []) or 'rule'
+        logger.debug(
+            f"  ➜ [规则预解析] 命中预解析: title='{rule_result.get('title')}', "
+            f"year={rule_result.get('year')}, type={rule_result.get('media_type')}, "
+            f"season={rule_result.get('season_number')}, episode={rule_result.get('episode_number')}, "
+            f"special={rule_result.get('is_special')} (confidence={rule_result.get('confidence')}, evidence={evidence_text})"
+        )
 
     # 辅助函数：用已锁定的类型去 TMDb 查官方标题
     def _fetch_title_by_id(ext_id, m_type):
@@ -5507,6 +5847,14 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
             )
             return tmdb_id, media_type, official_title or filename
 
+    if rule_result.get('tmdb_id') and rule_result.get('confidence') == 'high':
+        official_title = _fetch_title_by_id(rule_result.get('tmdb_id'), media_type)
+        logger.info(
+            f"  ➜ [规则预解析] 命中高置信显式 TMDb ID: {rule_result.get('tmdb_id')} "
+            f"(evidence={','.join(rule_result.get('evidence') or []) or 'rule'})"
+        )
+        return rule_result.get('tmdb_id'), media_type, official_title or title or filename
+
     # =================================================================
     # ★ 第二步：按优先级提取信息并定向查询
     # =================================================================
@@ -5536,7 +5884,7 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
         return None, None, None
 
     # 优先级 2: 提取 Title (Year) 进行搜索 (仅限文件)
-    def _search_by_title_year(text):
+    def _search_by_title_year(text, query_override=None, year_override=None, type_override=None):
         # 剔除 S01E01 等干扰字符 (连同前面的点和下划线一起剔除，防止留下 "The.Crown.")
         clean_text = re.sub(r'(?i)[\.\s\-_]*s\d{1,4}(?:e\d{1,4})?\b.*$', '', text).strip()
         clean_text = re.sub(r'(?i)[\.\s\-_]*ep?\d{1,4}\b.*$', '', clean_text).strip()
@@ -5552,6 +5900,11 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
             # 把年份从名字里剔除
             name_part = clean_text[:match_std.start()].strip()
 
+        if query_override:
+            name_part = str(query_override).strip()
+        if year_override not in [None, '']:
+            year_part = str(year_override).strip()
+
         # 清理名字里的点和下划线
         name_part = name_part.replace('.', ' ').replace('_', ' ').strip()
 
@@ -5559,12 +5912,13 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
 
         try:
             if api_key:
-                search_key = f"{name_part}_{year_part}_{media_type}"
+                search_media_type = type_override or media_type
+                search_key = f"{name_part}_{year_part}_{search_media_type}"
                 if search_key in _TMDB_SEARCH_CACHE:
                     results = _TMDB_SEARCH_CACHE[search_key]
                 else:
                     # 严格按照锁定的 media_type 搜索
-                    results = tmdb.search_media(query=name_part, api_key=api_key, item_type=media_type, year=year_part)
+                    results = tmdb.search_media(query=name_part, api_key=api_key, item_type=search_media_type, year=year_part)
                     _TMDB_SEARCH_CACHE[search_key] = results
 
                 if results and len(results) > 0:
@@ -5590,10 +5944,24 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
                         if part_match:
                             break
                             
-                    return str(best['id']), media_type, (best.get('title') or best.get('name'))
+                    return str(best['id']), search_media_type, (best.get('title') or best.get('name'))
         except Exception:
             pass
         return None
+
+    if rule_result.get('title') and rule_result.get('confidence') in ('medium', 'high'):
+        res = _search_by_title_year(
+            filename,
+            query_override=rule_result.get('title'),
+            year_override=rule_result.get('year'),
+            type_override=rule_result.get('media_type') or media_type
+        )
+        if res:
+            logger.info(
+                f"  ➜ [规则预解析] 规则命中后 TMDb 搜索成功: "
+                f"title='{rule_result.get('title')}', year={rule_result.get('year')}, type={rule_result.get('media_type') or media_type}"
+            )
+            return res
 
     # 2.1 优先从 filename 搜索
     res = _search_by_title_year(filename)
@@ -5661,6 +6029,12 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
                 ai_title = ai_result.get('title')
                 ai_year = ai_result.get('year')
                 ai_type = forced_media_type or ai_result.get('type') or media_type
+                if rule_result.get('title') and not ai_title:
+                    ai_title = rule_result.get('title')
+                if rule_result.get('year') and not ai_year:
+                    ai_year = rule_result.get('year')
+                if rule_result.get('media_type') and not forced_media_type:
+                    ai_type = rule_result.get('media_type')
                 
                 if api_key:
                     search_key = f"AI_{ai_title}_{ai_year}_{ai_type}"

--- a/tests/fixtures/p115_media_recognition_cases.json
+++ b/tests/fixtures/p115_media_recognition_cases.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "standard_movie",
+    "raw": "Dune.Part.Two.2024.2160p.WEB-DL.H265.DDP5.1.mkv",
+    "main_dir_name": "Dune Part Two (2024)",
+    "expect": {
+      "title": "Dune Part Two",
+      "year": 2024,
+      "media_type": "movie"
+    }
+  },
+  {
+    "name": "standard_tv_sxe",
+    "raw": "The.Last.of.Us.S01E03.1080p.NF.WEB-DL.mkv",
+    "main_dir_name": "The Last of Us",
+    "expect": {
+      "title": "The Last of Us",
+      "media_type": "tv",
+      "season_number": 1,
+      "episode_number": 3
+    }
+  },
+  {
+    "name": "chinese_season_episode",
+    "raw": "庆余年 第2季 第03集 4K.mkv",
+    "main_dir_name": "庆余年 第2季",
+    "expect": {
+      "title": "庆余年",
+      "media_type": "tv",
+      "season_number": 2,
+      "episode_number": 3
+    }
+  },
+  {
+    "name": "anime_special",
+    "raw": "My.Anime.SP01.1080p.BluRay.mkv",
+    "main_dir_name": "My Anime Specials",
+    "expect": {
+      "title": "My Anime",
+      "media_type": "tv",
+      "season_number": 0,
+      "episode_number": 1,
+      "is_special": true
+    }
+  },
+  {
+    "name": "anime_ova_cn",
+    "raw": "某动画 OVA 第1话 1080p.mkv",
+    "main_dir_name": "某动画 OVA",
+    "expect": {
+      "title": "某动画",
+      "media_type": "tv",
+      "season_number": 0,
+      "episode_number": 1,
+      "is_special": true
+    }
+  },
+  {
+    "name": "variety_date_episode",
+    "raw": "Amazing.Show.2024.05.17.1080p.WEB-DL.mkv",
+    "main_dir_name": "Amazing Show",
+    "expect": {
+      "title": "Amazing Show",
+      "media_type": "movie",
+      "year": 2024,
+      "episode_number": 20240517
+    }
+  },
+  {
+    "name": "explicit_tmdbid",
+    "raw": "Some.Movie.tmdbid=123456.1080p.mkv",
+    "main_dir_name": "Some Movie",
+    "expect": {
+      "tmdb_id": "123456",
+      "media_type": "movie"
+    }
+  },
+  {
+    "name": "noisy_release_group",
+    "raw": "[Group] City.of.God.2002.1080p.BluRay.x264.DTS-WiKi.mkv",
+    "main_dir_name": "City.of.God.2002",
+    "expect": {
+      "title": "City of God",
+      "year": 2002,
+      "media_type": "movie"
+    }
+  },
+  {
+    "name": "collection_sub_item",
+    "raw": "Spider-Man.2.2004.1080p.BluRay.x264.mkv",
+    "main_dir_name": "Spider-Man Collection",
+    "expect": {
+      "title": "Spider-Man 2",
+      "year": 2004,
+      "media_type": "movie"
+    }
+  },
+  {
+    "name": "fallback_miss",
+    "raw": "totally_unstructured_file.bin",
+    "main_dir_name": "misc",
+    "expect": {
+      "title": "totally unstructured file",
+      "confidence": "low"
+    }
+  }
+]

--- a/tests/test_p115_media_recognition.py
+++ b/tests/test_p115_media_recognition.py
@@ -1,0 +1,219 @@
+import importlib
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+ROOT = TESTS_DIR.parent
+FIXTURE_PATH = TESTS_DIR / "fixtures" / "p115_media_recognition_cases.json"
+
+
+def _install_test_stubs():
+    gevent_mod = types.ModuleType("gevent")
+    gevent_mod.spawn_later = lambda *args, **kwargs: None
+    sys.modules.setdefault("gevent", gevent_mod)
+
+    settings_db_mod = types.ModuleType("database.settings_db")
+    settings_db_mod.get_setting = lambda key: {}
+    settings_db_mod.save_setting = lambda key, value: None
+    sys.modules.setdefault("database.settings_db", settings_db_mod)
+
+    database_pkg = types.ModuleType("database")
+    database_pkg.settings_db = settings_db_mod
+    sys.modules.setdefault("database", database_pkg)
+
+    conn_mod = types.ModuleType("database.connection")
+    conn_mod.get_db_connection = lambda: None
+    sys.modules.setdefault("database.connection", conn_mod)
+
+    helpers_mod = types.ModuleType("tasks.helpers")
+    helpers_mod.check_series_completion = lambda *args, **kwargs: False
+    sys.modules.setdefault("tasks.helpers", helpers_mod)
+
+    tasks_pkg = types.ModuleType("tasks")
+    tasks_pkg.helpers = helpers_mod
+    sys.modules.setdefault("tasks", tasks_pkg)
+
+    analyzer_mod = types.ModuleType("handler.p115_media_analyzer")
+    class _Mixin:
+        pass
+    analyzer_mod.P115MediaAnalyzerMixin = _Mixin
+    sys.modules.setdefault("handler.p115_media_analyzer", analyzer_mod)
+
+
+_install_test_stubs()
+p115_service = importlib.import_module("handler.p115_service")
+
+
+class P115RecognitionRuleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture_cases = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    def test_rule_parse_fixture_coverage(self):
+        for case in self.fixture_cases:
+            with self.subTest(case=case["name"]):
+                result = p115_service._build_rule_parse_result(
+                    filename=case["raw"],
+                    main_dir_name=case.get("main_dir_name"),
+                    has_season_subdirs=False,
+                    forced_media_type=None,
+                    is_folder=False,
+                )
+                expect = case["expect"]
+                for key, value in expect.items():
+                    if key == "confidence":
+                        self.assertEqual(result.get(key), value)
+                    else:
+                        self.assertEqual(result.get(key), value)
+
+    def test_identify_media_enhanced_prefers_rule_search_input(self):
+        with mock.patch.object(
+            p115_service.tmdb,
+            "search_media",
+            return_value=[{"id": 999, "title": "City of God", "original_title": "Cidade de Deus"}],
+        ) as search_mock:
+            with mock.patch.dict(
+                p115_service.config_manager.APP_CONFIG,
+                {"tmdb_api_key": "fake"},
+                clear=False,
+            ):
+                tmdb_id, media_type, title = p115_service._identify_media_enhanced(
+                    "[Group] City.of.God.2002.1080p.BluRay.x264.DTS-WiKi.mkv",
+                    main_dir_name="City.of.God.2002",
+                    use_ai=False,
+                )
+        self.assertEqual(tmdb_id, "999")
+        self.assertEqual(media_type, "movie")
+        self.assertEqual(title, "City of God")
+        self.assertTrue(search_mock.called)
+        kwargs = search_mock.call_args.kwargs
+        self.assertEqual(kwargs["query"], "City of God")
+        self.assertEqual(kwargs["year"], "2002")
+
+    def test_identify_media_enhanced_explicit_tmdbid_rule_branch(self):
+        with mock.patch.object(
+            p115_service.tmdb,
+            "get_movie_details",
+            return_value={"title": "Some Movie"},
+        ) as details_mock:
+            with mock.patch.dict(
+                p115_service.config_manager.APP_CONFIG,
+                {"tmdb_api_key": "fake"},
+                clear=False,
+            ):
+                tmdb_id, media_type, title = p115_service._identify_media_enhanced(
+                    "Some.Movie.tmdbid=123456.1080p.mkv",
+                    main_dir_name="Some Movie",
+                    use_ai=False,
+                )
+
+        self.assertEqual(tmdb_id, "123456")
+        self.assertEqual(media_type, "movie")
+        self.assertEqual(title, "Some Movie")
+        details_mock.assert_called_once_with("123456", "fake")
+
+    def test_identify_media_enhanced_prefers_raw_ffprobe_identity_over_rule_tmdbid(self):
+        raw_ffprobe_json = {
+            "_etk": {
+                "tmdb_id": "777",
+                "media_type": "movie",
+            }
+        }
+        with mock.patch.object(
+            p115_service.tmdb,
+            "get_movie_details",
+            side_effect=[
+                {"title": "Cached Movie"},
+                {"title": "Rule Movie"},
+            ],
+        ) as details_mock:
+            with mock.patch.dict(
+                p115_service.config_manager.APP_CONFIG,
+                {"tmdb_api_key": "fake"},
+                clear=False,
+            ):
+                tmdb_id, media_type, title = p115_service._identify_media_enhanced(
+                    "Other.Title.tmdbid=123456.1080p.mkv",
+                    main_dir_name="Other Title",
+                    use_ai=False,
+                    raw_ffprobe_json=raw_ffprobe_json,
+                )
+
+        self.assertEqual(tmdb_id, "777")
+        self.assertEqual(media_type, "movie")
+        self.assertEqual(title, "Cached Movie")
+        details_mock.assert_called_once_with("777", "fake")
+
+    def test_identify_media_enhanced_keeps_folder_guard_without_id(self):
+        result = p115_service._identify_media_enhanced(
+            "Some Folder",
+            main_dir_name="Some Folder",
+            is_folder=True,
+            use_ai=False,
+        )
+        self.assertEqual(result, (None, None, None))
+
+    def test_rename_file_node_consumes_rule_episode_result(self):
+        organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
+        organizer.rename_config = {
+            "season_dir_format": ["season_name_en"],
+            "file_format": ["title_zh", "sep_space", "s_e"],
+        }
+        organizer.details = {"seasons": [], "last_episode_to_air": {}}
+        organizer.forced_season = None
+        organizer._fetch_and_parse_mediainfo = lambda *args, **kwargs: None
+        organizer._extract_video_info = lambda *args, **kwargs: {}
+        organizer._parse_season_episode_by_custom_regex = lambda *args, **kwargs: (None, None, None)
+        organizer._build_name_from_format = lambda format_array, **kwargs: (
+            f"S{int(kwargs.get('season_num') or 0):02d}E{int(kwargs.get('episode_num') or 0):02d}"
+            if "s_e" in format_array else f"Season {int(kwargs.get('season_num') or 0):02d}"
+        )
+
+        new_name, season_num, episode_num, s_name, _, _, _ = organizer._rename_file_node(
+            {"fn": "庆余年 第2季 第03集 4K.mkv", "rel_path": "庆余年 第2季"},
+            new_base_name="庆余年",
+            is_tv=True,
+            original_title="庆余年",
+            silent_log=True,
+        )
+
+        self.assertEqual(season_num, 2)
+        self.assertEqual(episode_num, 3)
+        self.assertEqual(s_name, "Season 02")
+        self.assertTrue(new_name.endswith(".mkv"))
+
+    def test_rename_file_node_falls_back_when_rules_miss(self):
+        organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
+        organizer.rename_config = {
+            "season_dir_format": ["season_name_en"],
+            "file_format": ["title_zh", "sep_space", "s_e"],
+        }
+        organizer.details = {"seasons": [], "last_episode_to_air": {}}
+        organizer.forced_season = None
+        organizer._fetch_and_parse_mediainfo = lambda *args, **kwargs: None
+        organizer._extract_video_info = lambda *args, **kwargs: {}
+        organizer._parse_season_episode_by_custom_regex = lambda *args, **kwargs: (None, None, None)
+        organizer._build_name_from_format = lambda format_array, **kwargs: (
+            f"S{int(kwargs.get('season_num') or 0):02d}E{int(kwargs.get('episode_num') or 0):02d}"
+            if "s_e" in format_array else f"Season {int(kwargs.get('season_num') or 0):02d}"
+        )
+
+        _, season_num, episode_num, _, _, _, _ = organizer._rename_file_node(
+            {"fn": "Show.S01E07.mkv", "rel_path": "Show"},
+            new_base_name="Show",
+            is_tv=True,
+            original_title="Show",
+            silent_log=True,
+        )
+
+        self.assertEqual(season_num, 1)
+        self.assertEqual(episode_num, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a deterministic pre-parse layer to the 115 media recognition chain in `handler/p115_service.py`.

It improves recognition of noisy file and directory names before TMDb / MoviePilot / AI fallback, and makes season / episode / special detection actually usable at the rename consumer point.

## What is included

* deterministic pre-parse for:

  * explicit `tmdbid`
  * cleaned title
  * year
  * media type guess
  * season / episode
  * special / OVA / SP style markers
  * date-based variety episode numbers
* `_identify_media_enhanced` consumes parse results to improve TMDb query input
* `_rename_file_node` consumes parse results to improve season / episode / special handling
* anonymous fixture-based unittest coverage for representative filename patterns

## What is not included

* webhook changes
* database schema changes
* UI changes
* SmartOrganizer global refactor
* any dedup-private logic or private rule sources

## Rationale

The existing 115 recognition chain works well for explicit IDs and common names, but it is weaker on noisy release names, Chinese season/episode markers, anime specials, and date-style episode naming.

This PR keeps the scope local to `handler/p115_service.py` and only adds a deterministic pre-parse enhancement layer. When no rule matches, the existing logic continues unchanged.

## Behavior and safety

* raw ffprobe / SHA1 cached identity still has higher priority than filename-derived rule hints
* explicit filename `tmdbid` remains supported
* normal title/year/type/season/episode rule output only enhances downstream recognition input
* when rule parsing misses or stays low confidence, the previous logic is preserved

## Test coverage

Added fixture and unittest coverage for:

* standard movie filenames
* standard `SxxExx`
* Chinese `第 N 季 / 第 N 集`
* anime `OVA / SP / 番外`
* date-based variety episodes
* explicit `tmdbid`
* release-group / codec / HDR / audio noise
* collection sub-item cases
* fallback miss cases
* cached identity preferred over filename `tmdbid`
