### PR TITLE
Normalize Telegram media candidates for MoviePilot recognition

### DIFF
--- a/handler/moviepilot.py
+++ b/handler/moviepilot.py
@@ -9,6 +9,7 @@ from typing import Dict, Any, Optional, List, Tuple
 import handler.tmdb as tmdb
 import constants
 from database import settings_db
+from handler.tg_media_candidate import candidate_to_recognition_hints, is_recognition_hint_eligible
 
 logger = logging.getLogger(__name__)
 
@@ -1092,6 +1093,54 @@ def recognize_media(title: str, config: Dict[str, Any] = None) -> Optional[tuple
     except Exception as e:
         logger.warning(f"  ➜ 调用 MoviePilot 识别接口失败: {e}")
         return None
+
+
+def build_recognition_queries_from_hints(hints: Dict[str, Any] = None, fallback_title: str = "") -> List[str]:
+    hints = candidate_to_recognition_hints(hints or {})
+    queries: List[str] = []
+
+    def _append(value: str):
+        value = str(value or '').strip()
+        if value and value not in queries:
+            queries.append(value)
+
+    allow_hint_queries = is_recognition_hint_eligible(hints)
+    identify_title = (hints.get('identify_title') or hints.get('title')) if allow_hint_queries else ""
+    clean_title = (hints.get('clean_title') or hints.get('title')) if allow_hint_queries else ""
+    year = hints.get('year')
+    media_type = hints.get('media_type')
+    season_number = hints.get('season_number')
+    is_special = bool(hints.get('is_special'))
+
+    _append(identify_title)
+    if identify_title and year:
+        _append(f"{identify_title} ({year})")
+
+    if clean_title and clean_title != identify_title:
+        _append(clean_title)
+        if year:
+            _append(f"{clean_title} ({year})")
+
+    if media_type == 'tv' and identify_title and season_number not in (None, ''):
+        try:
+            season_int = int(season_number)
+            _append(f"{identify_title} S{season_int:02d}")
+        except Exception:
+            pass
+
+    if media_type == 'tv' and identify_title and is_special:
+        _append(f"{identify_title} Special")
+
+    _append(fallback_title)
+    return queries
+
+
+def recognize_media_from_candidate(candidate_or_hints: Dict[str, Any] = None, fallback_title: str = "", config: Dict[str, Any] = None) -> Optional[tuple]:
+    for query in build_recognition_queries_from_hints(candidate_or_hints, fallback_title=fallback_title):
+        res = recognize_media(query, config=config)
+        if res:
+            return res
+    return None
 
 def cleanup_stale_washing_subscriptions(config: Dict[str, Any], timeout_days: int) -> List[Dict]:
     """

--- a/handler/p115_service.py
+++ b/handler/p115_service.py
@@ -20,6 +20,7 @@ import handler.tmdb as tmdb
 from tasks import helpers
 import utils
 from handler.p115_media_analyzer import P115MediaAnalyzerMixin
+from handler.tg_media_candidate import candidate_to_recognition_hints, is_recognition_hint_eligible, lookup_candidate_hint_for_name
 try:
     from p115client import P115Client
 except ImportError:
@@ -2721,6 +2722,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
         self.rating_priority = settings_db.get_setting('rating_priority') or utils.DEFAULT_RATING_PRIORITY
         self.country_map = settings_db.get_setting('country_mapping') or utils.DEFAULT_COUNTRY_MAPPING
         self.language_map = settings_db.get_setting('language_mapping') or utils.DEFAULT_LANGUAGE_MAPPING
+        self.recognition_hints = {}
 
         self.raw_metadata = self._fetch_raw_metadata()
         self.details = self.raw_metadata
@@ -3405,7 +3407,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
 
         return None, None, None
 
-    def _rename_file_node(self, file_node, new_base_name, year=None, is_tv=False, original_title=None, pre_fetched_mediainfo=None, local_pre_fetched_mediainfo=None, silent_log=False):
+    def _rename_file_node(self, file_node, new_base_name, year=None, is_tv=False, original_title=None, pre_fetched_mediainfo=None, local_pre_fetched_mediainfo=None, silent_log=False, recognition_hints=None):
         original_name = file_node.get('fn') or file_node.get('n') or file_node.get('file_name', '')
         rel_path = file_node.get('rel_path', '')
         rule_result = _build_rule_parse_result(
@@ -3415,6 +3417,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
             forced_media_type='tv' if is_tv else 'movie',
             is_folder=False,
         )
+        normalized_hints = candidate_to_recognition_hints(recognition_hints or file_node.get('_recognition_hints') or {})
         
         # ★ 修复 1：无后缀文件的提前返回，补齐为 8 个返回值
         if '.' not in original_name: 
@@ -3507,6 +3510,21 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
             if (real_info.get('season_number') not in (None, '') or real_info.get('episode_number') not in (None, '')) and not silent_log:
                 logger.info(
                     f"  ➜ [raw_ffprobe季集号] 命中缓存身份 -> "
+                    f"S{int(season_num if season_num is not None else 1):02d}"
+                    f"E{int(episode_num if episode_num is not None else 0):02d} | {original_name}"
+                )
+
+        if is_tv and normalized_hints:
+            if season_num is None and normalized_hints.get('season_number') is not None:
+                season_num = _se_int(normalized_hints.get('season_number'))
+            if episode_num is None and normalized_hints.get('episode_number') is not None:
+                episode_num = _se_int(normalized_hints.get('episode_number'))
+            if (
+                (normalized_hints.get('season_number') not in (None, '') or normalized_hints.get('episode_number') not in (None, ''))
+                and not silent_log
+            ):
+                logger.info(
+                    f"  ➜ [TG Candidate季集] 命中 hints -> "
                     f"S{int(season_num if season_num is not None else 1):02d}"
                     f"E{int(episode_num if episode_num is not None else 0):02d} | {original_name}"
                 )
@@ -3605,6 +3623,12 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
             # 4. 终极兜底
             if season_num is None:
                 season_num = 1
+
+        if is_tv and normalized_hints.get('is_special') and season_num is None:
+            season_num = 0
+
+        if is_tv and normalized_hints.get('is_special') and season_num == 1 and episode_num is None:
+            season_num = 0
 
         if is_tv and rule_result.get('is_special') and season_num is None:
             season_num = 0
@@ -3829,12 +3853,14 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                     except Exception:
                         pass
 
+                sub_hint = lookup_candidate_hint_for_name(sub_name, alt_texts=[root_name])
                 tmdb_id, sub_type, sub_title = _identify_media_enhanced(
                     sub_name, 
                     ai_translator=self.ai_translator, 
                     use_ai=self.use_ai,
                     is_folder=(str(sub_fc_val) == '0'),
-                    sha1=sub_sha1
+                    sha1=sub_sha1,
+                    recognition_hints=sub_hint
                 )
                 
                 # 2. 模糊匹配 (仅当有官方合集列表时)
@@ -3901,6 +3927,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                 logger.info(f"    ├─ 准备批量整理合集子项: {sub_title} -> ID:{tmdb_id} (共 {len(items)} 个文件)")
                 try:
                     organizer = SmartOrganizer(self.client, tmdb_id, sub_type, sub_title, self.ai_translator, self.use_ai)
+                    organizer.recognition_hints = sub_hint or {}
                     target_cid_for_sub = organizer.get_target_cid()
                     if organizer.execute(items, target_cid_for_sub):
                         processed_count += len(items)
@@ -4355,7 +4382,8 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                         file_item, safe_title, year=year, is_tv=(self.media_type=='tv'), 
                         original_title=original_title, pre_fetched_mediainfo=pre_fetched_mediainfo, 
                         local_pre_fetched_mediainfo=local_pre_fetched_mediainfo,
-                        silent_log=True  # ★ 开启静默，防止预扫描时重复打印日志
+                        silent_log=True,  # ★ 开启静默，防止预扫描时重复打印日志
+                        recognition_hints=self.recognition_hints,
                     )
                     key = (v_s, v_e, v_part) if self.media_type == 'tv' else ('movie', v_part)
                     # 电影只保留第一个视频作为基准 (通常电影只有一个正片)
@@ -4517,7 +4545,8 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                     original_title=original_title,
                     pre_fetched_mediainfo=pre_fetched_mediainfo,
                     local_pre_fetched_mediainfo=local_pre_fetched_mediainfo,
-                    silent_log=True
+                    silent_log=True,
+                    recognition_hints=self.recognition_hints,
                 )
 
                 # ★ 核心：只保留文件名
@@ -4589,7 +4618,8 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                 new_filename, season_num, episode_num, s_name, video_info, has_real_info, part_num = self._rename_file_node(
                     file_item, safe_title, year=year, is_tv=(self.media_type=='tv'), original_title=original_title,
                     pre_fetched_mediainfo=pre_fetched_mediainfo,
-                    local_pre_fetched_mediainfo=local_pre_fetched_mediainfo 
+                    local_pre_fetched_mediainfo=local_pre_fetched_mediainfo,
+                    recognition_hints=self.recognition_hints,
                 )
 
                 real_target_cid = final_home_cid
@@ -5861,7 +5891,7 @@ def _build_rule_parse_result(filename, main_dir_name=None, has_season_subdirs=Fa
     return result
 
 
-def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=False, forced_media_type=None, ai_translator=None, use_ai=False, is_folder=False, sha1=None, raw_ffprobe_json=None):
+def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=False, forced_media_type=None, ai_translator=None, use_ai=False, is_folder=False, sha1=None, raw_ffprobe_json=None, recognition_hints=None):
     """
     【绝对正确版】识别逻辑：
     1. 先定类型：综合主目录、子目录特征、文件名，判断是 Movie 还是 TV。
@@ -5882,6 +5912,13 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
         forced_media_type=forced_media_type,
         is_folder=is_folder,
     )
+    normalized_hints = candidate_to_recognition_hints(recognition_hints or {})
+    eligible_hints = normalized_hints if is_recognition_hint_eligible(normalized_hints) else {}
+    if normalized_hints:
+        if normalized_hints.get('media_type') and not forced_media_type:
+            media_type = normalized_hints.get('media_type')
+        if normalized_hints.get('identify_title') or normalized_hints.get('clean_title') or normalized_hints.get('title'):
+            title = normalized_hints.get('identify_title') or normalized_hints.get('clean_title') or normalized_hints.get('title')
 
     # =================================================================
     # ★ 第一步：铁腕判定媒体类型 (Movie or TV)
@@ -5907,6 +5944,14 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
             f"year={rule_result.get('year')}, type={rule_result.get('media_type')}, "
             f"season={rule_result.get('season_number')}, episode={rule_result.get('episode_number')}, "
             f"special={rule_result.get('is_special')} (confidence={rule_result.get('confidence')}, evidence={evidence_text})"
+        )
+
+    if normalized_hints:
+        logger.debug(
+            f"  ➜ [TG Candidate] 命中识别 hints: title='{normalized_hints.get('identify_title') or normalized_hints.get('clean_title') or normalized_hints.get('title')}', "
+            f"year={normalized_hints.get('year')}, type={normalized_hints.get('media_type')}, "
+            f"season={normalized_hints.get('season_number')}, episode={normalized_hints.get('episode_number')}, "
+            f"special={normalized_hints.get('is_special')} (confidence={normalized_hints.get('confidence')})"
         )
 
     # 辅助函数：用已锁定的类型去 TMDb 查官方标题
@@ -5955,6 +6000,15 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
                 f"{', lang:' + probe_identity.get('original_language') if probe_identity.get('original_language') else ''}"
             )
             return tmdb_id, media_type, official_title or filename
+
+    if normalized_hints.get('tmdb_id') and normalized_hints.get('confidence') == 'high':
+        hinted_type = normalized_hints.get('media_type') or media_type
+        official_title = _fetch_title_by_id(normalized_hints.get('tmdb_id'), hinted_type)
+        logger.info(
+            f"  ➜ [TG Candidate] 命中高置信显式 TMDb ID: {normalized_hints.get('tmdb_id')} "
+            f"(evidence={','.join(normalized_hints.get('evidence') or []) or 'candidate'})"
+        )
+        return normalized_hints.get('tmdb_id'), hinted_type, official_title or title or filename
 
     if rule_result.get('tmdb_id') and rule_result.get('confidence') == 'high':
         official_title = _fetch_title_by_id(rule_result.get('tmdb_id'), media_type)
@@ -6072,6 +6126,21 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
             )
             return res
 
+    if normalized_hints.get('identify_title') and normalized_hints.get('confidence') in ('medium', 'high'):
+        res = _search_by_title_year(
+            filename,
+            query_override=normalized_hints.get('identify_title') or normalized_hints.get('clean_title'),
+            year_override=normalized_hints.get('year'),
+            type_override=normalized_hints.get('media_type') or media_type,
+        )
+        if res:
+            logger.info(
+                f"  ➜ [TG Candidate] hints 命中后 TMDb 搜索成功: "
+                f"title='{normalized_hints.get('identify_title') or normalized_hints.get('clean_title')}', year={normalized_hints.get('year')}, "
+                f"type={normalized_hints.get('media_type') or media_type}"
+            )
+            return res
+
     # 2.1 优先从 filename 搜索
     res = _search_by_title_year(filename)
     if res: return res
@@ -6095,7 +6164,11 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
                 return _MP_PARSE_CACHE[target_name]
                 
             logger.debug(f"  ➜ 本地正则失败，尝试调用 MoviePilot 辅助识别: {target_name}")
-            mp_res = mp.recognize_media(target_name, config_manager.APP_CONFIG)
+            mp_res = mp.recognize_media_from_candidate(
+                eligible_hints if eligible_hints else rule_result,
+                fallback_title=target_name,
+                config=config_manager.APP_CONFIG
+            )
             
             if mp_res:
                 logger.info(f"  ➜ [MP辅助识别] 成功命中: {mp_res[2]} (ID:{mp_res[0]})")

--- a/handler/telegram.py
+++ b/handler/telegram.py
@@ -10,6 +10,7 @@ from handler.emby import get_emby_item_details
 from database import user_db, request_db, media_db
 from database.connection import get_db_connection
 import constants
+from handler.tg_media_candidate import build_channel_task_payload
 
 logger = logging.getLogger(__name__)
 
@@ -1505,24 +1506,16 @@ def _tg_start_hdhive_transfer(chat_id: str, selection_number: int):
         try:
             from handler.tg_userbot import tg_task_queue
 
-            task = {
-                "type": "channel_resource_complex",
-                "tmdb_id": tmdb_id,
-                "title": title,
-                "year": year,
-                "item_type": media_type,
-                "target_link": resource.get("target_link"),
-                "magnet_url": resource.get("magnet_url"),
-                "receive_code": resource.get("receive_code") or "",
-                "season_number": resource.get("season_number"),
-                "episode_number": resource.get("episode_number"),
-                "is_pack": bool(resource.get("is_pack")),
-                "is_completed_pack": bool(resource.get("is_completed_pack")),
-                "is_brainless": False,
-                # 手动选择频道搜索结果，直接放行转存。
-                "is_keyword_matched": True,
-                "is_subscribe": False,
-            }
+            task = build_channel_task_payload(
+                resource,
+                is_brainless=False,
+                is_keyword_matched=True,
+                is_subscribe=False,
+                title_override=title,
+                tmdb_id_override=tmdb_id,
+                media_type_override=media_type,
+                year_override=year,
+            )
 
             if not task.get("target_link") and not task.get("magnet_url"):
                 _tg_send_plain(chat_id, "❌ 当前频道资源缺少 115/影巢/磁力链接，无法转存。")

--- a/handler/tg_media_candidate.py
+++ b/handler/tg_media_candidate.py
@@ -1,0 +1,944 @@
+import copy
+import logging
+import re
+import threading
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+from utils import DEFAULT_TG_REGEX
+
+logger = logging.getLogger(__name__)
+
+TG_CANDIDATE_PARSE_VERSION = "v1"
+_CANDIDATE_HINT_TTL_SECONDS = 6 * 60 * 60
+_CANDIDATE_HINT_REGISTRY: List[Dict[str, Any]] = []
+_CANDIDATE_HINT_LOCK = threading.Lock()
+_LOOKUP_KEYS_BLOCKED = object()
+
+_QUALITY_WORDS = (
+    "WEB-DL", "WEBRIP", "BLURAY", "REMUX", "HDR", "DV", "DDP",
+    "HEVC", "H265", "H.265", "X265", "X264", "内嵌", "外挂",
+    "中字", "简中", "繁中", "ATMOS", "TRUEHD", "DTS", "AAC",
+)
+_PLATFORM_PATTERNS = (
+    ("NETFLIX", r"\b(?:NETFLIX|NF)\b"),
+    ("AMZN", r"\b(?:AMZN|AMAZON)\b"),
+    ("DSNP", r"\b(?:DSNP|DISNEY\+?)\b"),
+    ("HULU", r"\bHULU\b"),
+    ("MAX", r"\b(?:HMAX|MAX)\b"),
+    ("ATVP", r"\b(?:ATVP|APPLE\s*TV\+?)\b"),
+    ("WEB", r"\bWEB(?:-DL|RIP)?\b"),
+)
+_TITLE_NOISE_PATTERN = re.compile(
+    r"(?i)\b("
+    r"WEB[- ]?DL|WEBRIP|BLURAY|REMUX|HDR10\+?|HDR|DV|DOVI|ATMOS|"
+    r"HEVC|H\.?265|X265|H\.?264|X264|DDP\d?(?:\.\d)?|TRUEHD|DTS(?:-HD)?|AAC\d?(?:\.\d)?|"
+    r"2160P|1080P|720P|480P|4K|8K|10BIT|8BIT|中字|内嵌|外挂|简中|繁中|双语|国粤|"
+    r"COMPLETE|SEASON|PACK|EPISODE|OVA|OAD|SP|SPECIALS?|番外|特别篇|特別篇"
+    r")\b"
+)
+
+
+def channel_rule_matches(target_channel, chat_username="", chat_id=""):
+    target_channel = str(target_channel or "").strip().lower()
+    if not target_channel:
+        return True
+
+    chat_username = str(chat_username or "").strip().lower().lstrip("@")
+    chat_id = str(chat_id or "").strip()
+    target_clean = target_channel.lstrip("@")
+    target_id_clean = target_clean.replace("-100", "") if target_clean.startswith("-100") else target_clean
+    curr_id_clean = chat_id.replace("-100", "") if chat_id.startswith("-100") else chat_id
+
+    return (
+        chat_username == target_clean
+        or chat_id == target_channel
+        or curr_id_clean == target_id_clean
+    )
+
+
+def apply_channel_regex(text, custom_rules, default_rules, chat_username="", chat_id="", flags=re.IGNORECASE):
+    text = str(text or "")
+    applicable_rules = []
+
+    for rule_obj in (custom_rules or []):
+        if isinstance(rule_obj, str):
+            applicable_rules.append(rule_obj)
+            continue
+
+        pattern = str((rule_obj or {}).get("pattern", "")).strip()
+        target_channel = str((rule_obj or {}).get("channel", "")).strip().lower()
+        if not pattern:
+            continue
+        if channel_rule_matches(target_channel, chat_username=chat_username, chat_id=chat_id):
+            applicable_rules.append(pattern)
+
+    rules = applicable_rules + list(default_rules or [])
+    for rule in rules:
+        if not rule or not str(rule).strip():
+            continue
+        try:
+            match = re.search(rule, text, flags)
+            if match:
+                return match
+        except Exception as e:
+            logger.error(f"  ➜ [TG Candidate] 正则执行错误: {rule} -> {e}")
+    return None
+
+
+def normalize_text(text):
+    return re.sub(r"\s+", " ", str(text or "")).strip()
+
+
+def _normalize_url_key(value):
+    value = str(value or "").strip()
+    if not value:
+        return ""
+    return re.sub(r"(?<!:)/{2,}", "//", value.rstrip("/")).lower()
+
+
+def _extract_share_code_from_text(text):
+    match = re.search(r"115(?:cdn)?\.com/s/([a-zA-Z0-9]+)", str(text or ""), re.IGNORECASE)
+    return match.group(1).lower() if match else ""
+
+
+def _extract_message_lookup_key(source_chat_id="", source_username="", message_id=None):
+    message_id = str(message_id or "").strip()
+    if not message_id:
+        return ""
+    source_chat_id = str(source_chat_id or "").strip()
+    if source_chat_id:
+        return f"msg:{source_chat_id}:{message_id}"
+    source_username = str(source_username or "").strip().lower().lstrip("@")
+    if source_username:
+        return f"msg:{source_username}:{message_id}"
+    return ""
+
+
+def _collect_lookup_keys(target_link="", magnet_url="", receive_code="", source_chat_id="", source_username="", message_id=None):
+    keys = []
+
+    def _append(value):
+        value = str(value or "").strip()
+        if value and value not in keys:
+            keys.append(value)
+
+    target_link = str(target_link or "").strip()
+    if target_link:
+        _append(f"target:{_normalize_url_key(target_link)}")
+        share_code = _extract_share_code_from_text(target_link)
+        if share_code:
+            _append(f"share:{share_code}")
+            receive_code = str(receive_code or "").strip().lower()
+            if receive_code:
+                _append(f"sharepwd:{share_code}:{receive_code}")
+
+    magnet_url = str(magnet_url or "").strip()
+    if magnet_url:
+        _append(f"magnet:{magnet_url.lower()}")
+
+    msg_key = _extract_message_lookup_key(
+        source_chat_id=source_chat_id,
+        source_username=source_username,
+        message_id=message_id,
+    )
+    if msg_key:
+        _append(msg_key)
+
+    return keys
+
+
+def _expand_lookup_keys(*values):
+    keys = []
+    for value in values:
+        if isinstance(value, (list, tuple, set)):
+            for item in value:
+                for expanded in _expand_lookup_keys(item):
+                    if expanded not in keys:
+                        keys.append(expanded)
+            continue
+
+        value = str(value or "").strip()
+        if not value:
+            continue
+
+        if value.startswith(("target:", "share:", "sharepwd:", "magnet:", "msg:")):
+            normalized = value
+            if value.startswith("target:"):
+                normalized = f"target:{_normalize_url_key(value.split(':', 1)[1])}"
+            else:
+                normalized = value.lower()
+            if normalized not in keys:
+                keys.append(normalized)
+            continue
+
+        expanded = _collect_lookup_keys(target_link=value)
+        if expanded:
+            for item in expanded:
+                if item not in keys:
+                    keys.append(item)
+            continue
+
+        normalized = value.lower()
+        if normalized not in keys:
+            keys.append(normalized)
+    return keys
+
+
+def extract_message_urls(message) -> List[str]:
+    urls = []
+    entities = getattr(getattr(message, "message", message), "entities", None)
+    if entities:
+        for entity in entities:
+            url = getattr(entity, "url", None)
+            if url:
+                urls.append(url)
+
+    reply_markup = getattr(getattr(message, "message", message), "reply_markup", None)
+    if reply_markup and hasattr(reply_markup, "rows"):
+        for row in reply_markup.rows:
+            for button in getattr(row, "buttons", []) or []:
+                url = getattr(button, "url", None)
+                if url:
+                    urls.append(url)
+
+    seen = set()
+    deduped = []
+    for url in urls:
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        deduped.append(url)
+    return deduped
+
+
+def guess_size_text(text):
+    match = re.search(r"(\d+(?:\.\d+)?)\s*(TB|GB|G|MB|M)\b", str(text or ""), re.IGNORECASE)
+    if not match:
+        return ""
+    value, unit = match.group(1), match.group(2).upper()
+    if unit == "G":
+        unit = "GB"
+    elif unit == "M":
+        unit = "MB"
+    return f"{value}{unit}"
+
+
+def guess_resolution(text):
+    upper = str(text or "").upper()
+    for token in ("8K", "4K", "2160P", "1080P", "720P"):
+        if token in upper:
+            return "4K" if token == "2160P" else token
+    return ""
+
+
+def guess_quality_text(text):
+    lines = [re.sub(r"\s+", " ", line).strip() for line in str(text or "").splitlines() if line.strip()]
+    for line in lines:
+        upper = line.upper()
+        if any(word.upper() in upper for word in _QUALITY_WORDS):
+            return line[:120]
+    return lines[0][:120] if lines else ""
+
+
+def guess_title_from_text(text):
+    for line in str(text or "").splitlines():
+        line = re.sub(r"[#*_`>\[\]【】]+", " ", line).strip()
+        line = re.sub(r"^[^\w\u4e00-\u9fa5]+", "", line).strip()
+        if line:
+            return line[:80]
+    return ""
+
+
+def normalize_title_for_match(value):
+    text = str(value or "").lower()
+    return re.sub(r"[\s\-_·.．・:：,，;；!！?？()\[\]【】{}<>《》\"“”'’‘`~～/\\|]+", "", text)
+
+
+def extract_explicit_tmdb_id(text):
+    text = str(text or "")
+    patterns = [
+        r"\bTMDB\s*(?:ID|Id|id)?\s*[:：#-]?\s*(\d{2,10})\b",
+        r"\{\s*tmdb-(\d{2,10})\s*\}",
+        r"\btmdb-(\d{2,10})\b",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if match:
+            return match.group(1)
+    return None
+
+
+def extract_year_candidates(text):
+    years = set()
+    for match in re.finditer(r"(?<!\d)((?:19|20)\d{2})(?!\d)", str(text or "")):
+        try:
+            years.add(int(match.group(1)))
+        except Exception:
+            pass
+    return years
+
+
+def channel_text_matches_year(text, expected_year):
+    expected_year = str(expected_year or "").strip()
+    if not expected_year:
+        return True
+    try:
+        expected = int(expected_year[:4])
+    except Exception:
+        return True
+    return expected in extract_year_candidates(text)
+
+
+def channel_title_candidate_lines(text):
+    candidates = []
+    lines = [re.sub(r"\s+", " ", line).strip() for line in str(text or "").splitlines() if line.strip()]
+    title_patterns = [
+        r"(?:^|[\[【📺🎬🎥🎞️ ]+)(?:电影|影片|剧集|电视剧|番剧|动漫|片名|标题|名称)\s*[:：]\s*(.+)$",
+        r"^[\[【]([^\]】]{2,80})[\]】]",
+    ]
+    for line in lines[:12]:
+        clean = line.strip()
+        for pattern in title_patterns:
+            match = re.search(pattern, clean, re.IGNORECASE)
+            if match:
+                value = match.group(1).strip()
+                value = re.split(r"\s+(?:TMDB|评分|类型|分类|大小|质量|主演|标签)\s*[:：]", value, 1, flags=re.IGNORECASE)[0].strip()
+                if value:
+                    candidates.append(value)
+
+    meta_prefix = re.compile(
+        r"^(?:⭐|🌟|🏷|📁|💾|🎬|👥|🎭|🌏|🗣|📺|🔥|📎|🔗|简介|分享|标签|分类|类型|评分|主演|大小|质量|版本|语言|地区|字幕|链接|公映|投稿|搜索|机场)\s*[:：]",
+        re.IGNORECASE,
+    )
+    for line in lines[:6]:
+        clean = re.sub(r"[#*_`>]+", " ", line).strip()
+        if not clean or meta_prefix.search(clean):
+            continue
+        if re.search(r"https?://|TMDB\s*ID|#\w+", clean, re.IGNORECASE):
+            continue
+        if len(clean) <= 100:
+            candidates.append(clean)
+
+    seen = set()
+    result = []
+    for item in candidates:
+        key = item.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(item)
+    return result
+
+
+def channel_text_matches_query_title(text, query):
+    query = str(query or "").strip()
+    if not query:
+        return True
+
+    normalized_query = normalize_title_for_match(query)
+    if not normalized_query:
+        return True
+
+    candidates = channel_title_candidate_lines(text)
+    if not candidates:
+        return False
+
+    if len(normalized_query) >= 3:
+        for cand in candidates:
+            normalized_cand = normalize_title_for_match(cand)
+            if normalized_query in normalized_cand or normalized_cand in normalized_query:
+                return True
+
+    words = [
+        w.lower()
+        for w in re.findall(r"[A-Za-z0-9]+|[\u4e00-\u9fa5]{2,}", query)
+        if len(w.strip()) >= 2
+    ]
+    if not words:
+        return False
+
+    candidate_blob = " ".join(candidates).lower()
+    normalized_blob = normalize_title_for_match(candidate_blob)
+    hit = 0
+    for word in words:
+        if normalize_title_for_match(word) in normalized_blob or word in candidate_blob:
+            hit += 1
+
+    required = len(words) if len(words) <= 2 else max(2, int(len(words) * 0.7))
+    return hit >= required
+
+
+def _guess_year_from_title(title):
+    title = str(title or "")
+    match = re.search(r"(?<!\d)((?:19|20)\d{2})(?!\d)", title)
+    return int(match.group(1)) if match else None
+
+
+def _extract_season_episode(text):
+    season_number = None
+    episode_number = None
+    is_pack = False
+    is_completed_pack = False
+    evidence = []
+    raw = str(text or "")
+
+    if re.search(r"(完结|全\d+集|\d+集全)", raw, re.IGNORECASE):
+        is_completed_pack = True
+        is_pack = True
+        evidence.append("completed_pack")
+
+    range_match = re.search(r"S(\d{1,2})\s*E(?:P)?\s*(\d{1,4})\s*(?:-|~|至)\s*(?:E|EP)?\s*(\d{1,4})", raw, re.IGNORECASE)
+    if range_match:
+        season_number = int(range_match.group(1))
+        episode_number = int(range_match.group(3))
+        is_pack = True
+        evidence.append("episode_range")
+    else:
+        se_match = re.search(r"S(\d{1,2})\s*E(?:P)?\s*(\d{1,4})", raw, re.IGNORECASE)
+        if se_match:
+            season_number = int(se_match.group(1))
+            episode_number = int(se_match.group(2))
+            evidence.append("sxe")
+        else:
+            s_match = re.search(r"(?:S|Season|第)\s*(\d{1,2})\s*(?:季)?", raw, re.IGNORECASE)
+            e_match = re.search(r"(?:E|EP|Episode|第)\s*(\d{1,4})\s*(?:集|话|話|回)", raw, re.IGNORECASE)
+            if s_match:
+                season_number = int(s_match.group(1))
+                evidence.append("season")
+            if e_match:
+                episode_number = int(e_match.group(1))
+                evidence.append("episode")
+
+            if episode_number is None:
+                bulk_match = re.search(r"(?:更新至|全|至)(?:第)?\s*(\d{1,4})\s*(?:集|话|話|回)|(?:^|\s)\d{1,3}-(\d{1,4})(?:集|话|話|回)?", raw)
+                if bulk_match:
+                    ep_str = bulk_match.group(1) or bulk_match.group(2)
+                    if ep_str:
+                        episode_number = int(ep_str)
+                        is_pack = True
+                        evidence.append("bulk_episode")
+
+    date_match = re.search(r"\b((?:19|20)\d{2})[.\-_/](\d{1,2})[.\-_/](\d{1,2})\b", raw)
+    if date_match and episode_number is None:
+        episode_number = int(f"{int(date_match.group(2)):02d}{int(date_match.group(3)):02d}")
+        season_number = season_number if season_number is not None else 1
+        evidence.append("date_episode")
+
+    if episode_number is not None and season_number is None:
+        season_number = 1
+
+    return season_number, episode_number, is_pack, is_completed_pack, evidence
+
+
+def _detect_special(text):
+    return bool(re.search(r"(?i)\b(?:SP|OVA|OAD|SPECIALS?|番外|特别篇|特別篇)\b", str(text or "")))
+
+
+def _extract_platform_tag(text):
+    raw = str(text or "")
+    for label, pattern in _PLATFORM_PATTERNS:
+        if re.search(pattern, raw, re.IGNORECASE):
+            return label
+    return ""
+
+
+def _extract_release_group(text):
+    raw = str(text or "")
+    prefix_match = re.match(r"^\[(.{2,32}?)\]", raw)
+    if prefix_match:
+        group = prefix_match.group(1).strip()
+        if group and not re.search(r"\d{3,4}p", group, re.IGNORECASE):
+            return group[:32]
+
+    suffix_match = re.search(r"(?:-|_)([A-Za-z0-9][A-Za-z0-9.\-_]{1,24})$", raw)
+    if suffix_match:
+        group = suffix_match.group(1).strip("._- ")
+        if group and not re.search(r"(?i)WEB|BLURAY|REMUX|2160P|1080P|720P|AAC|HEVC|H264|H265", group):
+            return group[:32]
+    return ""
+
+
+def _clean_candidate_title(title):
+    title = str(title or "").strip()
+    if not title:
+        return ""
+
+    title = re.sub(r"^\[[^\]]{1,32}\]\s*", "", title).strip()
+    title = re.sub(r"^[【\[][^\]】]{1,32}[】\]]\s*", "", title).strip()
+    title = re.sub(r"(?i)^(?:group|team|字幕组)\s+", "", title).strip()
+    title = re.sub(r"^[^\w\u4e00-\u9fa5]+", "", title).strip()
+    title = re.sub(r"\{[^{}]*tmdb[-:=_ ]*\d+[^{}]*\}", "", title, flags=re.IGNORECASE).strip()
+    title = re.sub(r"\bTMDB\s*(?:ID|Id|id)?\s*[:：#-]?\s*\d{2,10}\b", "", title, flags=re.IGNORECASE).strip()
+    title = re.sub(r"[\[\(（【](?:19|20)\d{2}[\]\)）】]", "", title).strip()
+    title = re.sub(r"(?i)[\.\s\-_]*S\d{1,4}(?:E\d{1,4})?\b.*$", "", title).strip()
+    title = re.sub(r"(?i)[\.\s\-_]*EP?\d{1,4}\b.*$", "", title).strip()
+    title = re.sub(r"(?i)[\.\s\-_]*Season\s*\d{1,4}\b.*$", "", title).strip()
+    title = re.sub(r"(?i)[\.\s\-_]*第\s*\d{1,4}\s*[季集话話回].*$", "", title).strip()
+    title = re.sub(r"(?<!\d)(?:19|20)\d{2}(?:[ ._-](?:0?[1-9]|1[0-2]))(?:[ ._-](?:0?[1-9]|[12]\d|3[01]))?.*$", "", title).strip()
+    title = _TITLE_NOISE_PATTERN.sub(" ", title)
+    title = title.replace(".", " ").replace("_", " ")
+    title = re.sub(r"\s+", " ", title).strip(" -._")
+    return title[:120]
+
+
+def _derive_identify_title(clean_title, query=""):
+    title = _clean_candidate_title(clean_title or query or "")
+    title = re.sub(r"(?i)\b(?:OVA|OAD|SP|SPECIALS?|番外|特别篇|特別篇)\b", " ", title)
+    title = re.sub(r"\s+", " ", title).strip(" -._")
+    return title[:120]
+
+
+def _infer_media_type(text, expected_media_type=None, season_number=None, episode_number=None):
+    if expected_media_type in ("movie", "tv"):
+        return expected_media_type
+    raw = str(text or "")
+    if re.search(r"(?:\[|【)(?:电视剧|剧集|动漫|番剧)(?:\]|】)|(?:电视剧|剧集|动漫|番剧)[:：]", raw, re.IGNORECASE):
+        return "tv"
+    if re.search(r"(?:\[|【)电影(?:\]|】)|电影[:：]", raw, re.IGNORECASE):
+        return "movie"
+    if season_number is not None or episode_number is not None or _detect_special(raw):
+        return "tv"
+    tags = " ".join(re.findall(r"#\w+", raw))
+    if re.search(r"#(?:电视剧|日剧|韩剧|美剧|英剧|台剧|港剧|泰剧|短剧|动漫|番剧|剧集|动画)", tags, re.IGNORECASE):
+        return "tv"
+    return "movie"
+
+
+def build_tg_media_candidate(
+    text,
+    *,
+    urls: Optional[Iterable[str]] = None,
+    chat_username: str = "",
+    chat_id: str = "",
+    chat_title: str = "",
+    message_id: Any = None,
+    message_date: str = "",
+    message_link: str = "",
+    custom_regex: Optional[Dict[str, Any]] = None,
+    query: str = "",
+    expected_tmdb_id: Any = None,
+    expected_year: Any = None,
+    expected_media_type: Optional[str] = None,
+    strict_title_match: bool = False,
+):
+    text = str(text or "")
+    if not text:
+        return None
+
+    custom_regex = custom_regex or {}
+    urls = [str(u).strip() for u in (urls or []) if str(u or "").strip()]
+    target_link = None
+    receive_code = ""
+
+    inline_link_match = re.search(r"(https?://(?:115cdn|115)\.com/s/[a-zA-Z0-9]+(?:[?&]password=[a-zA-Z0-9]+)?)", text, re.IGNORECASE)
+    if inline_link_match:
+        inline_link = inline_link_match.group(1)
+        if inline_link not in urls:
+            urls = [inline_link] + urls
+
+    for url in urls:
+        if "115.com/s/" in url or "115cdn.com/s/" in url or "hdhive.com/resource/" in url:
+            target_link = url
+            pwd_in_url = apply_channel_regex(url, custom_regex.get("password", []), DEFAULT_TG_REGEX.get("password_url", []), chat_username, chat_id)
+            if pwd_in_url:
+                receive_code = pwd_in_url.group(1)
+            break
+
+    if not receive_code:
+        pwd_match = apply_channel_regex(text, custom_regex.get("password", []), DEFAULT_TG_REGEX.get("password_text", []), chat_username, chat_id)
+        if pwd_match:
+            receive_code = pwd_match.group(1)
+
+    magnet_match = re.search(r"(magnet:\?xt=urn:btih:[a-zA-Z0-9]+.*?|ed2k://\|file\|.*?\|/)", text, re.IGNORECASE | re.DOTALL)
+    magnet_url = magnet_match.group(1).strip() if magnet_match else None
+    if not target_link and not magnet_url:
+        return None
+
+    tmdb_id = None
+    tmdb_match = apply_channel_regex(text, custom_regex.get("tmdb", []), DEFAULT_TG_REGEX.get("tmdb", []), chat_username, chat_id)
+    if tmdb_match:
+        tmdb_id = tmdb_match.group(1)
+    if not tmdb_id:
+        tmdb_id = extract_explicit_tmdb_id(text)
+
+    if expected_tmdb_id and tmdb_id and str(tmdb_id) != str(expected_tmdb_id):
+        return None
+
+    if strict_title_match and query:
+        if not channel_text_matches_query_title(text, query):
+            return None
+        if expected_year and not channel_text_matches_year(text, expected_year):
+            return None
+
+    title = None
+    year = None
+    title_match = apply_channel_regex(text, custom_regex.get("title_year", []), DEFAULT_TG_REGEX.get("title_year", []), chat_username, chat_id, flags=0)
+    if title_match:
+        title = title_match.group(1).strip()
+        year = title_match.group(2)
+
+    original_title = title or guess_title_from_text(text) or query
+    clean_title = _clean_candidate_title(original_title)
+    identify_title = _derive_identify_title(clean_title, query=query)
+
+    if not year:
+        guessed_year = _guess_year_from_title(original_title)
+        if guessed_year is None:
+            year_candidates = sorted(extract_year_candidates(text))
+            guessed_year = year_candidates[0] if year_candidates else None
+        year = guessed_year
+
+    season_number, episode_number, is_pack, is_completed_pack, season_evidence = _extract_season_episode(text)
+    is_special = _detect_special(text)
+    media_type = _infer_media_type(text, expected_media_type=expected_media_type, season_number=season_number, episode_number=episode_number)
+
+    quality_text = guess_quality_text(text)
+    resolution = guess_resolution(text)
+    share_size = guess_size_text(text)
+    release_group = _extract_release_group(original_title or text)
+    platform_tag = _extract_platform_tag(text)
+
+    evidence = []
+    if tmdb_id:
+        evidence.append("explicit_tmdb")
+    if identify_title:
+        evidence.append("identify_title")
+    if year:
+        evidence.append("year")
+    if media_type == "tv":
+        evidence.append("media_type_tv")
+    evidence.extend(season_evidence)
+    if is_special:
+        evidence.append("special")
+    if platform_tag:
+        evidence.append("platform")
+    if release_group:
+        evidence.append("release_group")
+
+    confidence = "low"
+    if tmdb_id:
+        confidence = "high"
+    elif identify_title and (year or media_type == "tv" or episode_number is not None):
+        confidence = "medium"
+
+    snippet = normalize_text(text)
+    if len(snippet) > 180:
+        snippet = snippet[:179] + "…"
+
+    title_for_display = identify_title or clean_title or original_title or query or "频道资源"
+    return {
+        "_tg_source": "channel",
+        "source": "channel",
+        "source_kind": "channel",
+        "title": title_for_display,
+        "name": title_for_display,
+        "original_title": original_title or title_for_display,
+        "clean_title": clean_title or title_for_display,
+        "identify_title": identify_title or clean_title or title_for_display,
+        "year": year,
+        "remark": snippet,
+        "quality": quality_text,
+        "quality_text": quality_text,
+        "resolution": resolution or "未知",
+        "share_size": share_size,
+        "pan_type": "115" if target_link else "离线",
+        "unlock_points": 0,
+        "source_channel": chat_title or chat_username or chat_id,
+        "source_username": chat_username,
+        "source_chat_id": str(chat_id or ""),
+        "message_id": message_id,
+        "message_date": message_date,
+        "message_link": message_link,
+        "text": text,
+        "raw_text": text,
+        "tmdb_id": tmdb_id or expected_tmdb_id,
+        "item_type": media_type,
+        "media_type": media_type,
+        "target_link": target_link,
+        "magnet_url": magnet_url,
+        "receive_code": receive_code,
+        "season_number": season_number,
+        "episode_number": episode_number,
+        "is_special": is_special,
+        "is_pack": is_pack,
+        "is_completed_pack": is_completed_pack,
+        "release_group": release_group,
+        "platform_tag": platform_tag,
+        "confidence": confidence,
+        "evidence": evidence,
+        "matched_rules": list(evidence),
+        "conflict_reason": "",
+        "parse_version": TG_CANDIDATE_PARSE_VERSION,
+    }
+
+
+def build_channel_task_payload(candidate, *, is_brainless=False, is_keyword_matched=False, is_subscribe=True, title_override=None, tmdb_id_override=None, media_type_override=None, year_override=None):
+    candidate = candidate or {}
+    media_type = media_type_override or candidate.get("media_type") or candidate.get("item_type") or "movie"
+    title = title_override or candidate.get("identify_title") or candidate.get("clean_title") or candidate.get("title") or candidate.get("name")
+    payload = {
+        "type": "channel_resource_complex",
+        "tmdb_id": str(tmdb_id_override) if tmdb_id_override is not None else candidate.get("tmdb_id"),
+        "title": title,
+        "year": year_override if year_override is not None else candidate.get("year"),
+        "item_type": media_type,
+        "target_link": candidate.get("target_link"),
+        "magnet_url": candidate.get("magnet_url"),
+        "receive_code": candidate.get("receive_code") or "",
+        "season_number": candidate.get("season_number"),
+        "episode_number": candidate.get("episode_number"),
+        "is_special": bool(candidate.get("is_special")),
+        "is_pack": bool(candidate.get("is_pack")),
+        "is_completed_pack": bool(candidate.get("is_completed_pack")),
+        "is_brainless": bool(is_brainless),
+        "is_keyword_matched": bool(is_keyword_matched),
+        "is_subscribe": bool(is_subscribe),
+        "candidate": copy.deepcopy(candidate),
+    }
+    return payload
+
+
+def candidate_to_recognition_hints(candidate):
+    candidate = copy.deepcopy(candidate or {})
+    return {
+        "tmdb_id": candidate.get("tmdb_id"),
+        "title": candidate.get("title") or candidate.get("identify_title") or candidate.get("clean_title"),
+        "clean_title": candidate.get("clean_title") or candidate.get("title"),
+        "identify_title": candidate.get("identify_title") or candidate.get("clean_title") or candidate.get("title"),
+        "year": candidate.get("year"),
+        "media_type": candidate.get("media_type") or candidate.get("item_type"),
+        "season_number": candidate.get("season_number"),
+        "episode_number": candidate.get("episode_number"),
+        "is_special": bool(candidate.get("is_special")),
+        "quality_text": candidate.get("quality_text") or candidate.get("quality"),
+        "resolution": candidate.get("resolution"),
+        "release_group": candidate.get("release_group"),
+        "platform_tag": candidate.get("platform_tag"),
+        "raw_text": candidate.get("raw_text") or candidate.get("text"),
+        "target_link": candidate.get("target_link"),
+        "magnet_url": candidate.get("magnet_url"),
+        "receive_code": candidate.get("receive_code"),
+        "source_channel": candidate.get("source_channel"),
+        "source_username": candidate.get("source_username"),
+        "source_chat_id": candidate.get("source_chat_id"),
+        "message_id": candidate.get("message_id"),
+        "message_link": candidate.get("message_link"),
+        "confidence": candidate.get("confidence") or "low",
+        "evidence": list(candidate.get("evidence") or []),
+        "matched_rules": list(candidate.get("matched_rules") or []),
+        "conflict_reason": candidate.get("conflict_reason") or "",
+        "parse_version": candidate.get("parse_version") or TG_CANDIDATE_PARSE_VERSION,
+        "source": "tg_candidate",
+    }
+
+
+def is_recognition_hint_eligible(candidate_or_hints):
+    hints = candidate_to_recognition_hints(candidate_or_hints)
+    if hints.get("conflict_reason"):
+        return False
+    return hints.get("confidence") in ("medium", "high")
+
+
+def remember_candidate_hint(candidate_or_hints, ttl_seconds=_CANDIDATE_HINT_TTL_SECONDS):
+    hints = candidate_to_recognition_hints(candidate_or_hints)
+    if not hints.get("identify_title") and not hints.get("clean_title") and not hints.get("title") and not hints.get("tmdb_id"):
+        return
+
+    expiry = time.time() + max(int(ttl_seconds or 0), 60)
+    hints["_expiry_at"] = expiry
+    hints["_normalized_titles"] = [
+        normalize_title_for_match(hints.get("identify_title")),
+        normalize_title_for_match(hints.get("clean_title")),
+        normalize_title_for_match(hints.get("title")),
+    ]
+    hints["_normalized_titles"] = [x for x in hints["_normalized_titles"] if x]
+    hints["_lookup_keys"] = _collect_lookup_keys(
+        target_link=hints.get("target_link"),
+        magnet_url=hints.get("magnet_url"),
+        receive_code=hints.get("receive_code"),
+        source_chat_id=hints.get("source_chat_id"),
+        source_username=hints.get("source_username"),
+        message_id=hints.get("message_id"),
+    )
+
+    with _CANDIDATE_HINT_LOCK:
+        prune_candidate_hints_locked()
+        _CANDIDATE_HINT_REGISTRY.append(hints)
+        if len(_CANDIDATE_HINT_REGISTRY) > 200:
+            del _CANDIDATE_HINT_REGISTRY[:-200]
+
+
+def prune_candidate_hints_locked():
+    now = time.time()
+    _CANDIDATE_HINT_REGISTRY[:] = [item for item in _CANDIDATE_HINT_REGISTRY if item.get("_expiry_at", 0) > now]
+
+
+def lookup_candidate_hint(primary_text, *, alt_texts=None, media_type=None, season_number=None, lookup_key=None, lookup_keys=None):
+    texts = [str(primary_text or "").strip()]
+    texts.extend([str(x or "").strip() for x in (alt_texts or []) if str(x or "").strip()])
+    normalized_texts = [normalize_title_for_match(t) for t in texts if t]
+    provided_lookup_keys = _expand_lookup_keys(lookup_key, lookup_keys)
+    if not normalized_texts and not provided_lookup_keys:
+        return None
+
+    best_hint = None
+    best_score = 0
+    tied_hints = []
+    now = time.time()
+    with _CANDIDATE_HINT_LOCK:
+        prune_candidate_hints_locked()
+
+        if provided_lookup_keys:
+            strong_match = None
+            strong_score = -1
+            for hint in _CANDIDATE_HINT_REGISTRY:
+                if hint.get("_expiry_at", 0) <= now:
+                    continue
+                hint_type = hint.get("media_type")
+                if media_type and hint_type and media_type != hint_type:
+                    continue
+
+                hint_keys = hint.get("_lookup_keys", [])
+                if not hint_keys or not any(key in hint_keys for key in provided_lookup_keys):
+                    continue
+
+                score = 10
+                if season_number is not None and hint.get("season_number") not in (None, "", season_number):
+                    score -= 1
+                if hint.get("confidence") == "high":
+                    score += 1
+                if score > strong_score:
+                    strong_score = score
+                    strong_match = copy.deepcopy(hint)
+
+            if strong_match:
+                strong_match.pop("_expiry_at", None)
+                strong_match.pop("_normalized_titles", None)
+                strong_match.pop("_lookup_keys", None)
+                return strong_match
+
+            return None
+
+        for hint in _CANDIDATE_HINT_REGISTRY:
+            if hint.get("_expiry_at", 0) <= now:
+                continue
+            hint_type = hint.get("media_type")
+            if media_type and hint_type and media_type != hint_type:
+                continue
+
+            score = 0
+            for norm_text in normalized_texts:
+                for hint_title in hint.get("_normalized_titles", []):
+                    if not norm_text or not hint_title:
+                        continue
+                    if hint_title == norm_text:
+                        score = max(score, 5)
+                    elif hint_title in norm_text or norm_text in hint_title:
+                        score = max(score, 4)
+            if score and season_number is not None and hint.get("season_number") not in (None, "", season_number):
+                score -= 1
+            if hint.get("confidence") == "high":
+                score += 1
+            if score > best_score:
+                best_score = score
+                best_hint = copy.deepcopy(hint)
+                tied_hints = [hint]
+            elif score and score == best_score:
+                tied_hints.append(hint)
+
+    if best_score < 4:
+        return None
+
+    if len(tied_hints) > 1:
+        tied_key_sets = {
+            tuple(sorted(hint.get("_lookup_keys", [])))
+            for hint in tied_hints
+            if hint.get("_lookup_keys")
+        }
+        if len(tied_key_sets) > 1:
+            return None
+
+    best_hint.pop("_expiry_at", None)
+    best_hint.pop("_normalized_titles", None)
+    best_hint.pop("_lookup_keys", None)
+    return best_hint
+
+
+def _resolve_lookup_keys_for_name(primary_text, *, alt_texts=None, media_type=None, season_number=None):
+    texts = [str(primary_text or "").strip()]
+    texts.extend([str(x or "").strip() for x in (alt_texts or []) if str(x or "").strip()])
+    normalized_texts = [normalize_title_for_match(t) for t in texts if t]
+    if not normalized_texts:
+        return None
+
+    best_score = 0
+    matched_hints = []
+    now = time.time()
+    with _CANDIDATE_HINT_LOCK:
+        prune_candidate_hints_locked()
+        for hint in _CANDIDATE_HINT_REGISTRY:
+            if hint.get("_expiry_at", 0) <= now:
+                continue
+            hint_type = hint.get("media_type")
+            if media_type and hint_type and media_type != hint_type:
+                continue
+
+            score = 0
+            for norm_text in normalized_texts:
+                for hint_title in hint.get("_normalized_titles", []):
+                    if not norm_text or not hint_title:
+                        continue
+                    if hint_title == norm_text:
+                        score = max(score, 5)
+                    elif hint_title in norm_text or norm_text in hint_title:
+                        score = max(score, 4)
+            if score and season_number is not None and hint.get("season_number") not in (None, "", season_number):
+                score -= 1
+            if hint.get("confidence") == "high":
+                score += 1
+
+            if score > best_score:
+                best_score = score
+                matched_hints = [hint]
+            elif score and score == best_score:
+                matched_hints.append(hint)
+
+    if best_score < 4 or not matched_hints:
+        return None
+
+    strong_key_sets = {
+        tuple(sorted(hint.get("_lookup_keys", [])))
+        for hint in matched_hints
+        if hint.get("_lookup_keys")
+    }
+    if not strong_key_sets:
+        return None
+    if len(strong_key_sets) > 1:
+        return _LOOKUP_KEYS_BLOCKED
+    return list(next(iter(strong_key_sets)))
+
+
+def lookup_candidate_hint_for_name(primary_text, *, alt_texts=None, media_type=None, season_number=None):
+    lookup_keys = _resolve_lookup_keys_for_name(
+        primary_text,
+        alt_texts=alt_texts,
+        media_type=media_type,
+        season_number=season_number,
+    )
+    if lookup_keys is _LOOKUP_KEYS_BLOCKED:
+        return None
+    if lookup_keys:
+        return lookup_candidate_hint(
+            primary_text,
+            alt_texts=alt_texts,
+            media_type=media_type,
+            season_number=season_number,
+            lookup_keys=lookup_keys,
+        )
+    return lookup_candidate_hint(
+        primary_text,
+        alt_texts=alt_texts,
+        media_type=media_type,
+        season_number=season_number,
+    )

--- a/handler/tg_userbot.py
+++ b/handler/tg_userbot.py
@@ -14,6 +14,12 @@ import constants
 from database import settings_db
 from handler.p115_service import P115Service
 from utils import DEFAULT_TG_REGEX
+from handler.tg_media_candidate import (
+    build_channel_task_payload,
+    build_tg_media_candidate,
+    candidate_to_recognition_hints,
+    remember_candidate_hint,
+)
 from database.connection import get_db_connection
 from gevent import spawn
 
@@ -346,159 +352,31 @@ class TGUserBotManager:
             return None
 
         custom_regex = cfg.get('custom_regex', {})
-        all_urls = []
+        all_urls = self._extract_message_urls(event.message)
+        candidate = build_tg_media_candidate(
+            text,
+            urls=all_urls,
+            chat_username=chat_username,
+            chat_id=chat_id,
+            chat_title=getattr(chat, 'title', '') or chat_username or chat_id,
+            message_id=getattr(event.message, 'id', None),
+            message_date=(getattr(event.message, 'date', None).strftime('%Y-%m-%d %H:%M') if getattr(event.message, 'date', None) else ''),
+            message_link=(f"https://t.me/{chat_username}/{getattr(event.message, 'id', None)}" if chat_username and getattr(event.message, 'id', None) else ''),
+            custom_regex=custom_regex,
+        )
+        if not candidate:
+            return
 
-        # 1. 提取 Markdown/HTML 隐藏的超链接
-        if event.message.entities:
-            for entity in event.message.entities:
-                if hasattr(entity, 'url') and entity.url:
-                    all_urls.append(entity.url)
-
-        # 2. 提取底部内联键盘 (Inline Keyboard) 的按钮链接
-        if event.message.reply_markup and hasattr(event.message.reply_markup, 'rows'):
-            for row in event.message.reply_markup.rows:
-                for button in row.buttons:
-                    if hasattr(button, 'url') and button.url:
-                        all_urls.append(button.url)
-
-        # 3. 寻找目标链接 (115 或 中间页) 和 提取码
-        target_link = None
-        receive_code = ""
-
-        link_match = re.search(r'(https?://(?:115cdn|115)\.com/s/[a-zA-Z0-9]+(?:[?&]password=[a-zA-Z0-9]+)?)', text, re.IGNORECASE)
-        if link_match:
-            all_urls.insert(0, link_match.group(1))
-
-        for url in all_urls:
-            if '115.com/s/' in url or '115cdn.com/s/' in url or 'hdhive.com/resource/' in url:
-                target_link = url
-                pwd_in_url = _apply_regex(url, custom_regex.get('password', []), DEFAULT_TG_REGEX['password_url'], chat_username, chat_id)
-                if pwd_in_url:
-                    receive_code = pwd_in_url.group(1)
-                break
-
-        # 4. 如果 URL 里没有密码，再从正文里找
-        if not receive_code:
-            pwd_match = _apply_regex(text, custom_regex.get('password', []), DEFAULT_TG_REGEX['password_text'], chat_username, chat_id)
-            if pwd_match:
-                receive_code = pwd_match.group(1)
-
-        # 5. 提取 TMDB ID
-        tmdb_id = None
-        tmdb_match = _apply_regex(text, custom_regex.get('tmdb', []), DEFAULT_TG_REGEX['tmdb'], chat_username, chat_id)
-        if tmdb_match:
-            tmdb_id = tmdb_match.group(1)
-
-        # 6. 提取标题和年份
-        title = None
-        year = None
-        title_match = _apply_regex(text, custom_regex.get('title_year', []), DEFAULT_TG_REGEX['title_year'], chat_username, chat_id, flags=0)
-        if title_match:
-            title = title_match.group(1).strip()
-            title = re.sub(r'^\[.*?\]\s*', '', title).strip()
-            title = re.sub(r'^[^\w\u4e00-\u9fa5]+', '', title).strip()
-            year = title_match.group(2)
-
-        # 7. 提取季号和集号
-        season_number = None
-        episode_number = None
-        is_pack = False 
-        is_completed_pack = False 
-
-        if re.search(r'(完结|全\d+集|\d+集全)', text, re.IGNORECASE):
-            is_completed_pack = True
-            is_pack = True
-        
-        # ★ 季集自定义正则 (支持频道隔离)
-        custom_se = custom_regex.get('season_episode', [])
-        se_matched = False
-        for rule_obj in custom_se:
-            if isinstance(rule_obj, str):
-                pattern = rule_obj
-                target_channel = ""
-            else:
-                pattern = rule_obj.get('pattern', '').strip()
-                target_channel = rule_obj.get('channel', '').strip().lower()
-                
-            if not pattern: continue
-            
-            # 校验频道
-            if target_channel:
-                target_clean = target_channel.replace('-100', '') if target_channel.startswith('-100') else target_channel
-                curr_id_clean = chat_id.replace('-100', '') if chat_id.startswith('-100') else chat_id
-                if not (chat_username.lower() == target_clean or chat_id == target_channel or curr_id_clean == target_clean):
-                    continue
-                    
-            try:
-                match = re.search(pattern, text, re.IGNORECASE)
-                if match:
-                    groups = match.groups()
-                    if len(groups) >= 2:
-                        season_number = int(groups[0])
-                        episode_number = int(groups[1])
-                    elif len(groups) == 1:
-                        episode_number = int(groups[0])
-                    se_matched = True
-                    break
-            except Exception as e:
-                logger.error(f"  ➜ [频道监听] 季集自定义正则错误: {pattern} -> {e}")
-
-        if not se_matched:
-            range_match = re.search(r'S(\d{1,2})\s*E(?:P)?\s*(\d{1,4})\s*(?:-|~|至)\s*(?:E|EP)?\s*(\d{1,4})', text, re.IGNORECASE)
-            if range_match:
-                season_number = int(range_match.group(1))
-                episode_number = int(range_match.group(3)) 
-                is_pack = True
-            else:
-                se_match = re.search(r'S(\d{1,2})\s*E(?:P)?\s*(\d{1,4})', text, re.IGNORECASE)
-                if se_match:
-                    season_number = int(se_match.group(1))
-                    episode_number = int(se_match.group(2))
-                else:
-                    s_match = re.search(r'(?:S|Season|第)\s*(\d{1,2})\s*(?:季)?', text, re.IGNORECASE)
-                    e_match = re.search(r'(?:E|EP|Episode|第)\s*(\d{1,4})\s*(?:集|话)', text, re.IGNORECASE)
-                    if s_match: season_number = int(s_match.group(1))
-                    if e_match: episode_number = int(e_match.group(1))
-                    
-                    if episode_number is None:
-                        bulk_match = re.search(r'(?:更新至|全|至)(?:第)?\s*(\d{1,4})\s*(?:集|话)|(?:^|\s)\d{1,3}-(\d{1,4})(?:集|话)?', text)
-                        if bulk_match:
-                            ep_str = bulk_match.group(1) or bulk_match.group(2)
-                            if ep_str:
-                                episode_number = int(ep_str)
-                                is_pack = True 
-
-        if episode_number is not None and season_number is None:
-            season_number = 1
-
-        # 8. 精准判定媒体类型
-        item_type = 'movie' 
-        
-        # 1. 最高优先级：明确带有 [电影] / 【电影】 等标识，或者 电影:
-        if re.search(r'(?:\[|【)电影(?:\]|】)|(?:🎬|🎥|🎞️)?\s*电影[:：]', text, re.IGNORECASE):
-            item_type = 'movie'
-        # 2. 明确带有 [剧集] / [动漫] 等标识，或者 剧集:
-        elif re.search(r'(?:\[|【)(?:电视剧|剧集|动漫|番剧)(?:\]|】)|(?:📺|🖥️)?\s*(?:电视剧|剧集|动漫|番剧)[:：]', text, re.IGNORECASE):
-            item_type = 'tv'
-        # 3. 提取到了季号或集号，必然是剧集
-        elif season_number is not None or episode_number is not None:
-            item_type = 'tv'
-        # 4. 标签和正文前缀判定
-        else:
-            tags = " ".join(re.findall(r'#\w+', text))
-            # 先判断是否明确有电影标签 (优先级高于动画)
-            if re.search(r'#(?:电影|Movie)', tags, re.IGNORECASE):
-                item_type = 'movie'
-            # 再判断是否有剧集/动漫标签
-            elif re.search(r'#(?:电视剧|日剧|韩剧|美剧|英剧|台剧|港剧|泰剧|短剧|动漫|番剧|剧集|动画)', tags, re.IGNORECASE):
-                item_type = 'tv'
-            else:
-                header_text = "\n".join(text.split('\n')[:8])
-                # 同样，正文前8行先找电影关键字
-                if re.search(r'(电影|Movie)', header_text, re.IGNORECASE):
-                    item_type = 'movie'
-                elif re.search(r'(电视剧|日剧|韩剧|美剧|英剧|台剧|港剧|泰剧|短剧|动漫|番剧|剧集)', header_text, re.IGNORECASE):
-                    item_type = 'tv'
+        target_link = candidate.get('target_link')
+        receive_code = candidate.get('receive_code', '')
+        tmdb_id = candidate.get('tmdb_id')
+        title = candidate.get('title')
+        year = candidate.get('year')
+        season_number = candidate.get('season_number')
+        episode_number = candidate.get('episode_number')
+        is_pack = bool(candidate.get('is_pack'))
+        is_completed_pack = bool(candidate.get('is_completed_pack'))
+        item_type = candidate.get('media_type') or candidate.get('item_type') or 'movie'
 
         allowed_types = cfg.get('monitor_types', ['movie', 'tv'])
         
@@ -506,17 +384,7 @@ class TGUserBotManager:
         if item_type not in allowed_types and not is_brainless and not is_keyword_matched:
             return
 
-        is_magnet = text.lower().startswith('magnet:?')
-        is_ed2k = text.lower().startswith('ed2k://')
-        magnet_ed2k_match = re.search(r'(magnet:\?xt=urn:btih:[a-zA-Z0-9]+.*?|ed2k://\|file\|.*?\|/)', text, re.IGNORECASE)
-
-        # 提取磁力/ED2K
-        is_magnet = text.lower().startswith('magnet:?')
-        is_ed2k = text.lower().startswith('ed2k://')
-        magnet_ed2k_match = re.search(r'(magnet:\?xt=urn:btih:[a-zA-Z0-9]+.*?|ed2k://\|file\|.*?\|/)', text, re.IGNORECASE)
-        magnet_url = magnet_ed2k_match.group(1) if magnet_ed2k_match else None
-        if not magnet_url and (is_magnet or is_ed2k):
-            magnet_url = text.strip()
+        magnet_url = candidate.get('magnet_url')
 
         # =================================================================
         # ★ 核心分流逻辑 (统一合并到复杂校验流水线)
@@ -524,23 +392,14 @@ class TGUserBotManager:
         if (target_link or magnet_url) and (tmdb_id or title or is_brainless or is_keyword_matched):
             logger.debug(f"  ➜ [频道监听] 监听到频道资源 -> 标题: {title or '未知'}, TMDB: {tmdb_id or '缺失'} (S{season_number}E{episode_number}), 判定类型: {'剧集' if item_type=='tv' else '电影'}, 准备推入处理队列...")
             
-            tg_task_queue.put({
-                "type": "channel_resource_complex",
-                "tmdb_id": tmdb_id,
-                "title": title,
-                "year": year,
-                "item_type": item_type,
-                "target_link": target_link, # 115 分享链接
-                "magnet_url": magnet_url,   # 磁力/ED2K 链接
-                "receive_code": receive_code,
-                "season_number": season_number,
-                "episode_number": episode_number,
-                "is_pack": is_pack,
-                "is_completed_pack": is_completed_pack,
-                "is_brainless": is_brainless,
-                "is_keyword_matched": is_keyword_matched,
-                "is_subscribe": is_subscribe
-            })
+            tg_task_queue.put(
+                build_channel_task_payload(
+                    candidate,
+                    is_brainless=is_brainless,
+                    is_keyword_matched=is_keyword_matched,
+                    is_subscribe=is_subscribe,
+                )
+            )
 
 
     # ==========================================
@@ -826,152 +685,31 @@ class TGUserBotManager:
         custom_regex = cfg.get('custom_regex', {}) or {}
         urls = self._extract_message_urls(message)
 
-        target_link = None
-        receive_code = ''
-
-        for url in urls:
-            if ('115.com/s/' in url or '115cdn.com/s/' in url or 'hdhive.com/resource/' in url):
-                target_link = url
-                pwd_in_url = self._apply_search_regex(url, custom_regex.get('password', []), DEFAULT_TG_REGEX.get('password_url', []))
-                if pwd_in_url:
-                    receive_code = pwd_in_url.group(1)
-                break
-
-        if not receive_code:
-            pwd_match = self._apply_search_regex(text, custom_regex.get('password', []), DEFAULT_TG_REGEX.get('password_text', []))
-            if pwd_match:
-                receive_code = pwd_match.group(1)
-
-        magnet_match = re.search(r'(magnet:\?xt=urn:btih:[a-zA-Z0-9]+.*?|ed2k://\|file\|.*?\|/)', text, re.IGNORECASE | re.DOTALL)
-        magnet_url = magnet_match.group(1).strip() if magnet_match else None
-
-        if not target_link and not magnet_url:
-            return None
-
         chat_username = getattr(chat, 'username', '') or ''
         chat_id = str(getattr(chat, 'id', ''))
         chat_title = getattr(chat, 'title', '') or chat_username or chat_id
-
-        tmdb_id = None
-        tmdb_match = self._apply_search_regex(text, custom_regex.get('tmdb', []), DEFAULT_TG_REGEX.get('tmdb', []), chat_username, chat_id)
-        if tmdb_match:
-            tmdb_id = tmdb_match.group(1)
-        if not tmdb_id:
-            tmdb_id = self._extract_explicit_tmdb_id(text)
-
-        # 匹配优先级：
-        # 1. 频道正文明确写了 TMDb ID：只按 ID 判断。ID 相同直接通过；ID 不同直接丢弃。
-        # 2. 频道正文没有 TMDb ID：才使用“片名 + 年份”兜底，年份不一致或缺失都丢弃。
-        if expected_tmdb_id and tmdb_id:
-            if str(tmdb_id) != str(expected_tmdb_id):
-                logger.debug(
-                    "  ➜ [频道搜索] 丢弃 TMDb ID 不匹配结果：目标=%s，消息=%s，预览=%s",
-                    expected_tmdb_id, tmdb_id, self._normalize_text(text)[:80]
-                )
-                return None
-        elif strict_title_match and query:
-            if not self._channel_text_matches_query_title(text, query):
-                logger.debug(
-                    "  ➜ [频道搜索] 丢弃片名不匹配结果：搜索片名=%s，消息预览=%s",
-                    query, self._normalize_text(text)[:80]
-                )
-                return None
-            if expected_year and not self._channel_text_matches_year(text, expected_year):
-                logger.debug(
-                    "  ➜ [频道搜索] 丢弃年份不匹配结果：搜索片名=%s，目标年份=%s，消息预览=%s",
-                    query, expected_year, self._normalize_text(text)[:80]
-                )
-                return None
-
-        title = None
-        year = None
-        title_match = self._apply_search_regex(text, custom_regex.get('title_year', []), DEFAULT_TG_REGEX.get('title_year', []), chat_username, chat_id, flags=0)
-        if title_match:
-            title = title_match.group(1).strip()
-            title = re.sub(r'^\[.*?\]\s*', '', title).strip()
-            title = re.sub(r'^[^\w\u4e00-\u9fa5]+', '', title).strip()
-            year = title_match.group(2)
-
-        if not title:
-            title = query or self._guess_title_from_text(text)
-
-        season_number = None
-        episode_number = None
-        is_pack = False
-        is_completed_pack = False
-        if re.search(r'(完结|全\d+集|\d+集全)', text, re.IGNORECASE):
-            is_completed_pack = True
-            is_pack = True
-
-        range_match = re.search(r'S(\d{1,2})\s*E(?:P)?\s*(\d{1,4})\s*(?:-|~|至)\s*(?:E|EP)?\s*(\d{1,4})', text, re.IGNORECASE)
-        if range_match:
-            season_number = int(range_match.group(1))
-            episode_number = int(range_match.group(3))
-            is_pack = True
-        else:
-            se_match = re.search(r'S(\d{1,2})\s*E(?:P)?\s*(\d{1,4})', text, re.IGNORECASE)
-            if se_match:
-                season_number = int(se_match.group(1))
-                episode_number = int(se_match.group(2))
-            else:
-                s_match = re.search(r'(?:S|Season|第)\s*(\d{1,2})\s*(?:季)?', text, re.IGNORECASE)
-                e_match = re.search(r'(?:E|EP|Episode|第)\s*(\d{1,4})\s*(?:集|话)', text, re.IGNORECASE)
-                if s_match:
-                    season_number = int(s_match.group(1))
-                if e_match:
-                    episode_number = int(e_match.group(1))
-
-        if episode_number is not None and season_number is None:
-            season_number = 1
-
-        item_type = expected_media_type or ('tv' if season_number is not None or episode_number is not None else 'movie')
-        if re.search(r'(?:\[|【)(?:电视剧|剧集|动漫|番剧)(?:\]|】)|(?:电视剧|剧集|动漫|番剧)[:：]', text, re.IGNORECASE):
-            item_type = 'tv'
-        elif re.search(r'(?:\[|【)电影(?:\]|】)|电影[:：]', text, re.IGNORECASE):
-            item_type = 'movie'
-
         msg_id = getattr(message, 'id', None)
         date_obj = getattr(message, 'date', None)
         date_text = date_obj.strftime('%Y-%m-%d %H:%M') if date_obj else ''
         message_link = ''
         if chat_username and msg_id:
             message_link = f"https://t.me/{chat_username}/{msg_id}"
-
-        quality = self._guess_quality_text(text)
-        resolution = self._guess_resolution(text)
-        size_text = self._guess_size_text(text)
-        snippet = self._normalize_text(text)
-        if len(snippet) > 180:
-            snippet = snippet[:179] + '…'
-
-        return {
-            '_tg_source': 'channel',
-            'source': 'channel',
-            'title': title or query or '频道资源',
-            'name': title or query or '频道资源',
-            'remark': snippet,
-            'quality': quality,
-            'resolution': resolution or '未知',
-            'share_size': size_text,
-            'pan_type': '115' if target_link else '离线',
-            'unlock_points': 0,
-            'source_channel': chat_title,
-            'source_username': chat_username,
-            'source_chat_id': chat_id,
-            'message_id': msg_id,
-            'message_date': date_text,
-            'message_link': message_link,
-            'text': text,
-            'tmdb_id': tmdb_id or expected_tmdb_id,
-            'item_type': item_type,
-            'target_link': target_link,
-            'magnet_url': magnet_url,
-            'receive_code': receive_code,
-            'season_number': season_number,
-            'episode_number': episode_number,
-            'is_pack': is_pack,
-            'is_completed_pack': is_completed_pack,
-        }
+        return build_tg_media_candidate(
+            text,
+            urls=urls,
+            chat_username=chat_username,
+            chat_id=chat_id,
+            chat_title=chat_title,
+            message_id=msg_id,
+            message_date=date_text,
+            message_link=message_link,
+            custom_regex=custom_regex,
+            query=query,
+            expected_tmdb_id=expected_tmdb_id,
+            expected_year=expected_year,
+            expected_media_type=expected_media_type,
+            strict_title_match=strict_title_match,
+        )
 
     async def _search_channel_resources_async(self, query, media_type=None, tmdb_id=None, year=None, limit=10, extra_queries=None, include_tmdb_query=False, strict_title_match=False):
         """在已配置监听频道的历史消息里搜索资源。"""
@@ -1190,6 +928,7 @@ def _process_tg_queue():
                 continue
 
             if task_type == "channel_resource_complex":
+                candidate = task.get('candidate') or {}
                 tmdb_id = task.get('tmdb_id')
                 title = task.get('title')
                 year = task.get('year')
@@ -1203,6 +942,25 @@ def _process_tg_queue():
                 is_subscribe = task.get('is_subscribe', True)
 
                 item_type = task.get('item_type', 'movie')
+                candidate_hints = candidate_to_recognition_hints(candidate) if candidate else {}
+                if candidate_hints:
+                    remember_candidate_hint(candidate_hints)
+                    tmdb_id = tmdb_id or candidate_hints.get('tmdb_id')
+                    title = candidate_hints.get('identify_title') or candidate_hints.get('clean_title') or title
+                    year = year or candidate_hints.get('year')
+                    item_type = candidate_hints.get('media_type') or item_type
+                    if season_number is None:
+                        season_number = candidate_hints.get('season_number')
+                    if episode_number is None:
+                        episode_number = candidate_hints.get('episode_number')
+                    task['tmdb_id'] = tmdb_id
+                    task['title'] = title
+                    task['year'] = year
+                    task['item_type'] = item_type
+                    task['season_number'] = season_number
+                    task['episode_number'] = episode_number
+                    task['is_special'] = bool(task.get('is_special') or candidate_hints.get('is_special'))
+
                 if not tmdb_id and title:
                     logger.debug(f"  ➜ [频道监听] 缺失 TMDB ID，正在通过 TMDb 接口反查: {title} ({year}), 严格限定类型: {'剧集' if item_type=='tv' else '电影'}...")
                     from handler import tmdb

--- a/routes/subscription.py
+++ b/routes/subscription.py
@@ -6,6 +6,7 @@ from database import settings_db
 from handler.hdhive_client import HDHiveClient
 from tasks.hdhive import task_download_from_hdhive, filter_hdhive_resources
 from handler.tg_userbot import TGUserBotManager, tg_task_queue
+from handler.tg_media_candidate import build_channel_task_payload
 import threading
 
 subscription_bp = Blueprint('subscription_bp', __name__, url_prefix='/api/subscription')
@@ -503,24 +504,18 @@ def trigger_cloud_download():
         if not target_link and not magnet_url:
             return jsonify({"success": False, "message": "频道资源缺少可转存链接"}), 400
 
-        tg_task_queue.put({
-            "type": "channel_resource_complex",
-            "tmdb_id": tmdb_id,
-            "title": title,
-            "year": data.get('year') or resource.get('year'),
-            "item_type": media_type,
-            "target_link": target_link,
-            "magnet_url": magnet_url,
-            "receive_code": resource.get('receive_code') or '',
-            "season_number": resource.get('season_number'),
-            "episode_number": resource.get('episode_number'),
-            "is_pack": bool(resource.get('is_pack')),
-            "is_completed_pack": bool(resource.get('is_completed_pack')),
-            # 手动云搜索选择的资源应直接转存，不再要求已订阅/追剧。
-            "is_brainless": True,
-            "is_keyword_matched": True,
-            "is_subscribe": False
-        })
+        tg_task_queue.put(
+            build_channel_task_payload(
+                resource,
+                is_brainless=True,
+                is_keyword_matched=True,
+                is_subscribe=False,
+                title_override=title,
+                tmdb_id_override=tmdb_id,
+                media_type_override=media_type,
+                year_override=data.get('year') or resource.get('year'),
+            )
+        )
         return jsonify({"success": True, "message": "已推送频道资源转存任务，后台正在处理！"})
 
     return jsonify({"success": False, "message": "未知资源来源，无法执行转存"}), 400

--- a/tasks/p115.py
+++ b/tasks/p115.py
@@ -26,6 +26,7 @@ from handler.p115_service import (
     _identify_media_enhanced
 )
 from handler.p115_media_analyzer import P115MediaAnalyzerMixin
+from handler.tg_media_candidate import lookup_candidate_hint_for_name
 
 logger = logging.getLogger(__name__)
 
@@ -301,10 +302,12 @@ def task_scan_and_organize_115(processor=None):
                         if group_sha1:
                             break
 
+                recognition_hints = lookup_candidate_hint_for_name(g_top_name, alt_texts=[top_name], media_type=forced_type)
                 tmdb_id, media_type, title = _identify_media_enhanced(
                     g_top_name, main_dir_name=g_top_name, has_season_subdirs=group["has_season_dir"],
                     forced_media_type=forced_type, ai_translator=ai_translator, use_ai=use_ai, is_folder=False,
-                    sha1=group_sha1  # 👈 关键：传入 SHA1
+                    sha1=group_sha1,  # 👈 关键：传入 SHA1
+                    recognition_hints=recognition_hints
                 )
                 
                 if not tmdb_id:
@@ -314,6 +317,7 @@ def task_scan_and_organize_115(processor=None):
                     
                 try:
                     organizer = SmartOrganizer(client, tmdb_id, media_type, title, ai_translator, use_ai)
+                    organizer.recognition_hints = recognition_hints or {}
                     if season_num is not None: organizer.forced_season = season_num
                     
                     # 执行整理 (直接传 None，让 execute 内部统一计算最终的 target_cid)

--- a/tasks/subscriptions.py
+++ b/tasks/subscriptions.py
@@ -24,6 +24,7 @@ try:
 except Exception:
     TGUserBotManager = None
     tg_task_queue = None
+from handler.tg_media_candidate import build_channel_task_payload
 
 try:
     from handler.shared_subscription_service import try_consume_shared_resource, report_shared_gap
@@ -561,24 +562,18 @@ def _enqueue_channel_resource_download(resource: Dict, tmdb_id, media_type: str,
         except Exception:
             season_number = target_season
 
-    tg_task_queue.put({
-        'type': 'channel_resource_complex',
-        'tmdb_id': str(tmdb_id) if tmdb_id is not None else resource.get('tmdb_id'),
-        'title': title or resource.get('title') or resource.get('name'),
-        'year': resource.get('year'),
-        'item_type': media_type,
-        'target_link': target_link,
-        'magnet_url': magnet_url,
-        'receive_code': resource.get('receive_code') or '',
-        'season_number': season_number,
-        'episode_number': resource.get('episode_number'),
-        'is_pack': bool(resource.get('is_pack')),
-        'is_completed_pack': bool(resource.get('is_completed_pack')),
-        # 统一订阅自动选中的频道资源已经由本函数做过过滤，交给队列时直接放行。
-        'is_brainless': True,
-        'is_keyword_matched': True,
-        'is_subscribe': False,
-    })
+    tg_task_queue.put(
+        build_channel_task_payload(
+            resource,
+            is_brainless=True,
+            is_keyword_matched=True,
+            is_subscribe=False,
+            title_override=title or resource.get('title') or resource.get('name'),
+            tmdb_id_override=str(tmdb_id) if tmdb_id is not None else resource.get('tmdb_id'),
+            media_type_override=media_type,
+            year_override=resource.get('year'),
+        ) | {'season_number': season_number}
+    )
     return True
 
 

--- a/tests/fixtures/tg_media_candidate_cases.json
+++ b/tests/fixtures/tg_media_candidate_cases.json
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "movie_basic",
+    "raw_text": "[Group] Dune.Part.Two.2024.2160p.WEB-DL.H265.DDP5.1\nTMDB ID: 693134\nhttps://115.com/s/abc123?password=1a2b",
+    "query": "Dune Part Two",
+    "expected": {
+      "tmdb_id": "693134",
+      "identify_title": "Dune Part Two",
+      "year": 2024,
+      "media_type": "movie"
+    }
+  },
+  {
+    "name": "tv_sxe",
+    "raw_text": "The.Last.of.Us.S01E03.1080p.NF.WEB-DL\nhttps://115.com/s/def456",
+    "query": "The Last of Us",
+    "expected": {
+      "identify_title": "The Last of Us",
+      "media_type": "tv",
+      "season_number": 1,
+      "episode_number": 3,
+      "platform_tag": "NETFLIX"
+    }
+  },
+  {
+    "name": "chinese_season_episode",
+    "raw_text": "庆余年 第2季 第03集 4K 杜比视界\nhttps://115.com/s/ghi789",
+    "query": "庆余年",
+    "expected": {
+      "identify_title": "庆余年",
+      "media_type": "tv",
+      "season_number": 2,
+      "episode_number": 3
+    }
+  },
+  {
+    "name": "anime_special",
+    "raw_text": "某动画 OVA 第1话 1080p 内嵌中字\nhttps://115.com/s/jkl012",
+    "query": "某动画",
+    "expected": {
+      "identify_title": "某动画",
+      "media_type": "tv",
+      "season_number": 1,
+      "episode_number": 1,
+      "is_special": true
+    }
+  },
+  {
+    "name": "variety_date",
+    "raw_text": "Amazing.Show.2024.05.17.1080p.WEB-DL\nhttps://115.com/s/mno345",
+    "query": "Amazing Show",
+    "expected": {
+      "identify_title": "Amazing Show",
+      "year": 2024,
+      "episode_number": 517
+    }
+  },
+  {
+    "name": "multi_links",
+    "raw_text": "Noisy.Show.S01E08.1080p.AMZN.WEB-DL\n备用网址 https://example.com/x\nhttps://115.com/s/pqr678",
+    "query": "Noisy Show",
+    "expected": {
+      "identify_title": "Noisy Show",
+      "media_type": "tv",
+      "season_number": 1,
+      "episode_number": 8,
+      "platform_tag": "AMZN"
+    }
+  },
+  {
+    "name": "fallback_miss",
+    "raw_text": "just some text with magnet:?xt=urn:btih:abcdef1234567890",
+    "query": "",
+    "expected": {
+      "confidence": "low"
+    }
+  }
+]

--- a/tests/test_tg_media_candidate_flow.py
+++ b/tests/test_tg_media_candidate_flow.py
@@ -1,0 +1,368 @@
+import importlib
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+FIXTURE_PATH = TESTS_DIR / "fixtures" / "tg_media_candidate_cases.json"
+
+
+def _install_test_stubs():
+    gevent_mod = types.ModuleType("gevent")
+    gevent_mod.spawn_later = lambda *args, **kwargs: None
+    gevent_mod.spawn = lambda *args, **kwargs: None
+    sys.modules.setdefault("gevent", gevent_mod)
+
+    telethon_mod = types.ModuleType("telethon")
+    telethon_mod.TelegramClient = object
+    telethon_mod.events = types.SimpleNamespace(NewMessage=object)
+    sys.modules.setdefault("telethon", telethon_mod)
+
+    telethon_errors = types.ModuleType("telethon.errors")
+    telethon_errors.SessionPasswordNeededError = Exception
+    telethon_errors.AuthKeyUnregisteredError = Exception
+    sys.modules.setdefault("telethon.errors", telethon_errors)
+
+    settings_db_mod = types.ModuleType("database.settings_db")
+    settings_db_mod.get_setting = lambda key: {}
+    settings_db_mod.save_setting = lambda key, value: None
+    sys.modules.setdefault("database.settings_db", settings_db_mod)
+
+    media_db_mod = types.ModuleType("database.media_db")
+    media_db_mod.get_series_local_children_info = lambda *args, **kwargs: {}
+    sys.modules.setdefault("database.media_db", media_db_mod)
+
+    database_pkg = types.ModuleType("database")
+    database_pkg.settings_db = settings_db_mod
+    database_pkg.media_db = media_db_mod
+    sys.modules.setdefault("database", database_pkg)
+
+    conn_mod = types.ModuleType("database.connection")
+    conn_mod.get_db_connection = lambda: None
+    sys.modules.setdefault("database.connection", conn_mod)
+
+    helpers_mod = types.ModuleType("tasks.helpers")
+    helpers_mod.check_series_completion = lambda *args, **kwargs: False
+    sys.modules.setdefault("tasks.helpers", helpers_mod)
+
+    tasks_pkg = types.ModuleType("tasks")
+    tasks_pkg.helpers = helpers_mod
+    sys.modules.setdefault("tasks", tasks_pkg)
+
+    analyzer_mod = types.ModuleType("handler.p115_media_analyzer")
+    class _Mixin:
+        pass
+    analyzer_mod.P115MediaAnalyzerMixin = _Mixin
+    sys.modules.setdefault("handler.p115_media_analyzer", analyzer_mod)
+
+
+_install_test_stubs()
+tg_candidate = importlib.import_module("handler.tg_media_candidate")
+moviepilot = importlib.import_module("handler.moviepilot")
+p115_service = importlib.import_module("handler.p115_service")
+
+
+class TgMediaCandidateFlowTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture_cases = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    def test_candidate_fixture_coverage(self):
+        for case in self.fixture_cases:
+            with self.subTest(case=case["name"]):
+                candidate = tg_candidate.build_tg_media_candidate(
+                    case["raw_text"],
+                    urls=["https://115.com/s/test123"],
+                    chat_username="demo",
+                    chat_id="10001",
+                    chat_title="Demo Channel",
+                    message_id=88,
+                    message_date="2025-01-01 10:00",
+                    message_link="https://t.me/demo/88",
+                    custom_regex={},
+                    query=case.get("query", ""),
+                )
+                self.assertIsNotNone(candidate)
+                for key, value in case["expected"].items():
+                    self.assertEqual(candidate.get(key), value)
+
+    def test_payload_keeps_candidate_and_legacy_fields(self):
+        candidate = tg_candidate.build_tg_media_candidate(
+            "The.Last.of.Us.S01E03.1080p.NF.WEB-DL\nhttps://115.com/s/abc123",
+            urls=["https://115.com/s/abc123"],
+            chat_username="demo",
+            chat_id="10001",
+            chat_title="Demo",
+            query="The Last of Us",
+        )
+        payload = tg_candidate.build_channel_task_payload(candidate, is_keyword_matched=True, is_subscribe=False)
+        self.assertIn("candidate", payload)
+        self.assertEqual(payload["candidate"]["identify_title"], "The Last of Us")
+        self.assertEqual(payload["title"], "The Last of Us")
+        self.assertEqual(payload["item_type"], "tv")
+        self.assertEqual(payload["season_number"], 1)
+        self.assertEqual(payload["episode_number"], 3)
+
+    def test_moviepilot_queries_use_candidate_titles_before_fallback(self):
+        candidate = {
+            "identify_title": "The Last of Us",
+            "clean_title": "The Last of Us",
+            "year": 2023,
+            "media_type": "tv",
+            "season_number": 1,
+            "confidence": "medium",
+        }
+        queries = moviepilot.build_recognition_queries_from_hints(candidate, fallback_title="The.Last.of.Us.S01E03.1080p.NF.WEB-DL")
+        self.assertEqual(queries[0], "The Last of Us")
+        self.assertIn("The Last of Us (2023)", queries)
+        self.assertIn("The Last of Us S01", queries)
+        self.assertEqual(queries[-1], "The.Last.of.Us.S01E03.1080p.NF.WEB-DL")
+
+    def test_moviepilot_queries_fall_back_for_low_confidence_hints(self):
+        queries = moviepilot.build_recognition_queries_from_hints(
+            {
+                "identify_title": "The Last of Us",
+                "clean_title": "The Last of Us",
+                "year": 2023,
+                "media_type": "tv",
+                "confidence": "low",
+            },
+            fallback_title="The.Last.of.Us.S01E03.1080p.NF.WEB-DL",
+        )
+        self.assertEqual(queries, ["The.Last.of.Us.S01E03.1080p.NF.WEB-DL"])
+
+    def test_moviepilot_queries_fall_back_for_conflict_hints(self):
+        queries = moviepilot.build_recognition_queries_from_hints(
+            {
+                "identify_title": "The Last of Us",
+                "clean_title": "The Last of Us",
+                "year": 2023,
+                "media_type": "tv",
+                "confidence": "high",
+                "conflict_reason": "title_mismatch",
+            },
+            fallback_title="The.Last.of.Us.S01E03.1080p.NF.WEB-DL",
+        )
+        self.assertEqual(queries, ["The.Last.of.Us.S01E03.1080p.NF.WEB-DL"])
+
+    def test_identify_media_enhanced_prefers_high_confidence_hint_tmdb(self):
+        hints = {
+            "tmdb_id": "12345",
+            "media_type": "tv",
+            "identify_title": "The Last of Us",
+            "confidence": "high",
+            "evidence": ["explicit_tmdb"],
+        }
+        with mock.patch.object(
+            p115_service.tmdb,
+            "get_tv_details",
+            return_value={"name": "The Last of Us"},
+        ) as details_mock:
+            with mock.patch.dict(
+                p115_service.config_manager.APP_CONFIG,
+                {"tmdb_api_key": "fake"},
+                clear=False,
+            ):
+                tmdb_id, media_type, title = p115_service._identify_media_enhanced(
+                    "The.Last.of.Us.S01E03.1080p.NF.WEB-DL.mkv",
+                    main_dir_name="The Last of Us",
+                    use_ai=False,
+                    recognition_hints=hints,
+                )
+
+        self.assertEqual(tmdb_id, "12345")
+        self.assertEqual(media_type, "tv")
+        self.assertEqual(title, "The Last of Us")
+        details_mock.assert_called_once_with("12345", "fake")
+
+    def test_moviepilot_recognition_uses_candidate_queries(self):
+        with mock.patch.object(
+            moviepilot,
+            "recognize_media",
+            side_effect=[None, ("555", "tv", "The Last of Us")],
+        ) as recognize_mock:
+            res = moviepilot.recognize_media_from_candidate(
+                {
+                    "identify_title": "The Last of Us",
+                    "clean_title": "The Last of Us",
+                    "year": 2023,
+                    "media_type": "tv",
+                    "confidence": "high",
+                },
+                fallback_title="The.Last.of.Us.S01E03.1080p.NF.WEB-DL",
+            )
+        self.assertEqual(res, ("555", "tv", "The Last of Us"))
+        self.assertEqual(recognize_mock.call_args_list[0].args[0], "The Last of Us")
+        self.assertEqual(recognize_mock.call_args_list[1].args[0], "The Last of Us (2023)")
+
+    def test_identify_media_enhanced_moviepilot_falls_back_for_low_confidence_hint(self):
+        with mock.patch.object(
+            p115_service.settings_db,
+            "get_setting",
+            return_value={"moviepilot_recognition": True},
+        ):
+            with mock.patch.object(
+                p115_service.tmdb,
+                "search_media",
+                return_value=[],
+            ):
+                with mock.patch("handler.moviepilot.recognize_media_from_candidate") as mp_mock:
+                    mp_mock.return_value = None
+                    p115_service._identify_media_enhanced(
+                        "The.Last.of.Us.S01E03.1080p.NF.WEB-DL.mkv",
+                        main_dir_name="The.Last.of.Us.S01E03.1080p.NF.WEB-DL",
+                        use_ai=False,
+                        recognition_hints={
+                            "identify_title": "The Last of Us",
+                            "clean_title": "The Last of Us",
+                            "year": 2023,
+                            "media_type": "tv",
+                            "confidence": "low",
+                        },
+                    )
+
+        args, kwargs = mp_mock.call_args
+        self.assertEqual(args[0].get("title"), "The Last of Us")
+        self.assertEqual(kwargs["fallback_title"], "The.Last.of.Us.S01E03.1080p.NF.WEB-DL.mkv")
+
+    def test_lookup_and_remember_candidate_hint_round_trip(self):
+        tg_candidate.remember_candidate_hint(
+            {
+                "identify_title": "The Last of Us",
+                "clean_title": "The Last of Us",
+                "media_type": "tv",
+                "season_number": 1,
+                "episode_number": 3,
+                "confidence": "medium",
+                "target_link": "https://115.com/s/shareabc?password=pass1",
+                "receive_code": "pass1",
+            },
+            ttl_seconds=600,
+        )
+        hit = tg_candidate.lookup_candidate_hint(
+            "The.Last.of.Us.S01E03.1080p",
+            media_type="tv",
+            lookup_key="sharepwd:shareabc:pass1",
+        )
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit["identify_title"], "The Last of Us")
+        self.assertEqual(hit["season_number"], 1)
+        self.assertEqual(hit["episode_number"], 3)
+
+    def test_lookup_candidate_hint_prefers_strong_key(self):
+        tg_candidate.remember_candidate_hint(
+            {
+                "identify_title": "Dune",
+                "clean_title": "Dune",
+                "media_type": "movie",
+                "confidence": "medium",
+                "target_link": "https://115.com/s/shareaaa?password=code1",
+                "receive_code": "code1",
+            },
+            ttl_seconds=600,
+        )
+        tg_candidate.remember_candidate_hint(
+            {
+                "identify_title": "Dune: Part Two",
+                "clean_title": "Dune Part Two",
+                "media_type": "movie",
+                "confidence": "high",
+                "target_link": "https://115.com/s/sharebbb?password=code2",
+                "receive_code": "code2",
+            },
+            ttl_seconds=600,
+        )
+
+        hit = tg_candidate.lookup_candidate_hint(
+            "Dune.2024.1080p.WEB-DL",
+            media_type="movie",
+            lookup_key="sharepwd:sharebbb:code2",
+        )
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit["identify_title"], "Dune: Part Two")
+
+    def test_lookup_candidate_hint_does_not_fallback_to_title_when_strong_key_misses(self):
+        tg_candidate.remember_candidate_hint(
+            {
+                "identify_title": "Dune",
+                "clean_title": "Dune",
+                "media_type": "movie",
+                "confidence": "medium",
+                "target_link": "https://115.com/s/shareaaa?password=code1",
+                "receive_code": "code1",
+            },
+            ttl_seconds=600,
+        )
+
+        hit = tg_candidate.lookup_candidate_hint(
+            "Dune.2021.1080p.WEB-DL",
+            media_type="movie",
+            lookup_key="sharepwd:sharezzz:code9",
+        )
+        self.assertIsNone(hit)
+
+    def test_lookup_candidate_hint_title_fallback_without_strong_key(self):
+        tg_candidate.remember_candidate_hint(
+            {
+                "identify_title": "The Last of Us",
+                "clean_title": "The Last of Us",
+                "media_type": "tv",
+                "season_number": 1,
+                "episode_number": 3,
+                "confidence": "medium",
+            },
+            ttl_seconds=600,
+        )
+        hit = tg_candidate.lookup_candidate_hint("The.Last.of.Us.S01E03.1080p", media_type="tv")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit["identify_title"], "The Last of Us")
+
+    def test_lookup_candidate_hint_for_name_uses_resolved_strong_key(self):
+        tg_candidate.remember_candidate_hint(
+            {
+                "identify_title": "Dune: Part Two",
+                "clean_title": "Dune Part Two",
+                "media_type": "movie",
+                "confidence": "high",
+                "target_link": "https://115.com/s/sharebbb?password=code2",
+                "receive_code": "code2",
+            },
+            ttl_seconds=600,
+        )
+        hit = tg_candidate.lookup_candidate_hint_for_name("Dune.Part.Two.2024.1080p", media_type="movie")
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit["identify_title"], "Dune: Part Two")
+
+    def test_lookup_candidate_hint_for_name_blocks_ambiguous_strong_keys(self):
+        tg_candidate.remember_candidate_hint(
+            {
+                "identify_title": "Dune",
+                "clean_title": "Dune",
+                "media_type": "movie",
+                "confidence": "medium",
+                "target_link": "https://115.com/s/shareaaa?password=code1",
+                "receive_code": "code1",
+            },
+            ttl_seconds=600,
+        )
+        tg_candidate.remember_candidate_hint(
+            {
+                "identify_title": "Dune",
+                "clean_title": "Dune",
+                "media_type": "movie",
+                "confidence": "medium",
+                "target_link": "https://115.com/s/sharebbb?password=code2",
+                "receive_code": "code2",
+            },
+            ttl_seconds=600,
+        )
+        hit = tg_candidate.lookup_candidate_hint_for_name("Dune.2021.1080p", media_type="movie")
+        self.assertIsNone(hit)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a normalized Telegram media candidate layer and wires it into the existing 115 / p115 recognition flow.

It makes Telegram channel monitoring, historical search, and subscription fallback produce the same structured media candidate, keeps that context in the task payload, and lets MoviePilot / TMDb / p115 consume cleaner recognition input instead of only dirty filenames.

## What is included

- unified Telegram media candidate builder for:
  - real-time channel monitoring
  - channel historical search
  - subscription fallback channel picks
- candidate payload now keeps:
  - raw text
  - message metadata
  - source channel info
  - cleaned / identify title
  - year / media type / tmdb id
  - season / episode / special flags
  - quality / resolution / release group / platform
  - confidence / evidence
- queue payload keeps legacy fields for compatibility and adds full `candidate`
- `_process_tg_queue` now prefers candidate hints before falling back to legacy title/year/type
- MoviePilot recognition input is enhanced via candidate-derived queries
- p115 recognition and rename stages can consume candidate hints after transfer
- hint lookup now prefers strong keys and blocks ambiguous same-title matches
- anonymous unittest fixtures for Telegram candidate parsing and downstream flow

## Why

Before this change, Telegram parsing was split across multiple entry points and most structured context was dropped before recognition:
- historical search had richer fields than real-time monitoring
- queue payload only kept simplified title/year/type/tmdb/link fields
- MoviePilot recognition only saw dirty directory or filename text
- p115 rename logic could not reuse Telegram parsing results

This PR keeps the scope local and makes Telegram parsing feed existing recognition chains instead of creating a separate subsystem.

## Behavior and safety

- legacy task payload fields are preserved
- Telegram connection / listening / reconnect logic is unchanged
- high-confidence cached identity and explicit TMDb IDs still outrank normal rule hints
- MoviePilot remains optional and only affects recognition when enabled
- low-confidence or conflicting candidate data falls back to the previous TMDb / p115 / AI flow
- strong-key hint lookup prevents same-title resources from reusing the wrong Telegram candidate

## Tests

Added coverage for:
- Telegram message -> candidate normalization
- real-time and historical search sharing the same candidate builder
- queue payload retaining candidate context
- MoviePilot recognition query construction from candidate fields
- low-confidence / conflicting candidate fallback
- high-confidence tmdb id hint priority
- strong-key hint lookup
- strong-key mismatch not falling back to fuzzy title match
- fallback to fuzzy title only when no strong key is available
- anonymous cases for:
  - movie
  - standard TV episodes
  - Chinese season/episode markers
  - anime special / OVA
  - date-style variety episodes
  - explicit tmdbid
  - noisy release strings
  - multiple links
  - fallback miss