### PR TITLE
Fix HDHive TG hint handoff and noisy anime filename parsing

### DIFF
--- a/handler/fixtures/p115_media_recognition_cases.json
+++ b/handler/fixtures/p115_media_recognition_cases.json
@@ -96,6 +96,18 @@
     }
   },
   {
+    "name": "anime_tv_release_noise",
+    "raw": "When Will Ayumu Make His Move？.2022.S01E12.1080p.BluRay.Remux.H.264.FLAC 2.0-AnimeF@ADE.mkv",
+    "main_dir_name": "When Will Ayumu Make His Move？.2022.S01E12.1080p.BluRay.Remux.H.264.FLAC 2.0-AnimeF@ADE.mkv",
+    "expect": {
+      "title": "When Will Ayumu Make His Move",
+      "year": 2022,
+      "media_type": "tv",
+      "season_number": 1,
+      "episode_number": 12
+    }
+  },
+  {
     "name": "fallback_miss",
     "raw": "totally_unstructured_file.bin",
     "main_dir_name": "misc",

--- a/handler/p115_service.py
+++ b/handler/p115_service.py
@@ -5662,6 +5662,7 @@ def _clean_rule_title(text):
     value = str(text).replace('\\', '/')
     value = os.path.basename(value.strip())
     value = os.path.splitext(value)[0]
+    value = re.sub(r'[？?！!：:；;，,、]+', ' ', value)
 
     for pattern in _NOISE_TOKEN_PATTERNS:
         value = re.sub(pattern, ' ', value)
@@ -5671,6 +5672,10 @@ def _clean_rule_title(text):
     value = re.sub(r'(?i)\b(?:tmdb|tmdbid)[=\-_ ]*\d+\b', ' ', value)
     value = re.sub(r'(?<!\d)(?:19|20)\d{2}(?!\d)', ' ', value)
     value = re.sub(r'(?i)\b(?:specials?|ova|oad|sp|extra(?:s)?|collection|complete)\b', ' ', value)
+    value = re.sub(r'(?i)\b(?:h[ ._-]?26[45]|x26[45])\b', ' ', value)
+    value = re.sub(r'(?i)\b(?:flac|aac|ddp|dd|dts|truehd|atmos)[ ._-]*\d(?:\.\d)?\b', ' ', value)
+    value = re.sub(r'(?i)(?:[-_. ]+)?[A-Za-z0-9][A-Za-z0-9._-]{1,20}@[A-Za-z0-9][A-Za-z0-9._-]{1,20}$', ' ', value)
+    value = re.sub(r'(?<!\w)\d\.\d(?!\w)', ' ', value)
     value = re.sub(r'[\[\]\(\)\{\}]', ' ', value)
     value = re.sub(r'[._]+', ' ', value)
     value = re.sub(r'\s+', ' ', value).strip(' -_./')

--- a/handler/tg_media_candidate.py
+++ b/handler/tg_media_candidate.py
@@ -14,6 +14,7 @@ _CANDIDATE_HINT_TTL_SECONDS = 6 * 60 * 60
 _CANDIDATE_HINT_REGISTRY: List[Dict[str, Any]] = []
 _CANDIDATE_HINT_LOCK = threading.Lock()
 _LOOKUP_KEYS_BLOCKED = object()
+_TMDB_ALIAS_CACHE: Dict[str, List[str]] = {}
 
 _QUALITY_WORDS = (
     "WEB-DL", "WEBRIP", "BLURAY", "REMUX", "HDR", "DV", "DDP",
@@ -729,6 +730,7 @@ def candidate_to_recognition_hints(candidate):
         "matched_rules": list(candidate.get("matched_rules") or []),
         "conflict_reason": candidate.get("conflict_reason") or "",
         "parse_version": candidate.get("parse_version") or TG_CANDIDATE_PARSE_VERSION,
+        "alias_titles": list(candidate.get("alias_titles") or []),
         "source": "tg_candidate",
     }
 
@@ -740,6 +742,52 @@ def is_recognition_hint_eligible(candidate_or_hints):
     return hints.get("confidence") in ("medium", "high")
 
 
+def _fetch_tmdb_alias_titles(tmdb_id, media_type):
+    tmdb_id = str(tmdb_id or "").strip()
+    media_type = str(media_type or "").strip().lower()
+    if not tmdb_id or media_type not in ("movie", "tv"):
+        return []
+
+    cache_key = f"{media_type}:{tmdb_id}"
+    if cache_key in _TMDB_ALIAS_CACHE:
+        return list(_TMDB_ALIAS_CACHE.get(cache_key) or [])
+
+    aliases: List[str] = []
+    try:
+        import config_manager
+        import constants
+        import handler.tmdb as tmdb
+
+        api_key = config_manager.APP_CONFIG.get(constants.CONFIG_OPTION_TMDB_API_KEY)
+        if not api_key:
+            _TMDB_ALIAS_CACHE[cache_key] = []
+            return []
+
+        details = tmdb.get_tv_details(tmdb_id, api_key) if media_type == "tv" else tmdb.get_movie_details(tmdb_id, api_key)
+        if details:
+            if media_type == "tv":
+                candidates = [
+                    details.get("name"),
+                    details.get("original_name"),
+                    details.get("english_title"),
+                ]
+            else:
+                candidates = [
+                    details.get("title"),
+                    details.get("original_title"),
+                    details.get("english_title"),
+                ]
+            for value in candidates:
+                value = normalize_text(value)
+                if value and value not in aliases:
+                    aliases.append(value)
+    except Exception:
+        aliases = []
+
+    _TMDB_ALIAS_CACHE[cache_key] = list(aliases)
+    return aliases
+
+
 def remember_candidate_hint(candidate_or_hints, ttl_seconds=_CANDIDATE_HINT_TTL_SECONDS):
     hints = candidate_to_recognition_hints(candidate_or_hints)
     if not hints.get("identify_title") and not hints.get("clean_title") and not hints.get("title") and not hints.get("tmdb_id"):
@@ -747,11 +795,22 @@ def remember_candidate_hint(candidate_or_hints, ttl_seconds=_CANDIDATE_HINT_TTL_
 
     expiry = time.time() + max(int(ttl_seconds or 0), 60)
     hints["_expiry_at"] = expiry
+    alias_titles = list(hints.get("alias_titles") or [])
+    if hints.get("tmdb_id") and hints.get("media_type") and hints.get("confidence") in ("medium", "high"):
+        for alias in _fetch_tmdb_alias_titles(hints.get("tmdb_id"), hints.get("media_type")):
+            if alias and alias not in alias_titles:
+                alias_titles.append(alias)
+    hints["alias_titles"] = alias_titles
     hints["_normalized_titles"] = [
         normalize_title_for_match(hints.get("identify_title")),
         normalize_title_for_match(hints.get("clean_title")),
         normalize_title_for_match(hints.get("title")),
     ]
+    hints["_normalized_titles"].extend(
+        normalize_title_for_match(alias)
+        for alias in alias_titles
+        if alias
+    )
     hints["_normalized_titles"] = [x for x in hints["_normalized_titles"] if x]
     hints["_lookup_keys"] = _collect_lookup_keys(
         target_link=hints.get("target_link"),

--- a/handler/tg_media_candidate_flow.py
+++ b/handler/tg_media_candidate_flow.py
@@ -363,6 +363,73 @@ class TgMediaCandidateFlowTests(unittest.TestCase):
         hit = tg_candidate.lookup_candidate_hint_for_name("Dune.2021.1080p", media_type="movie")
         self.assertIsNone(hit)
 
+    def test_lookup_candidate_hint_for_name_can_use_tmdb_alias_titles(self):
+        with mock.patch.object(
+            tg_candidate,
+            "_fetch_tmdb_alias_titles",
+            return_value=["When Will Ayumu Make His Move", "即使如此依旧步步逼近"],
+        ):
+            tg_candidate.remember_candidate_hint(
+                {
+                    "tmdb_id": "116168",
+                    "identify_title": "即使如此依旧步步逼近",
+                    "clean_title": "即使如此依旧步步逼近",
+                    "media_type": "tv",
+                    "season_number": 1,
+                    "confidence": "high",
+                    "target_link": "https://115.com/s/shareayumu?password=pass1",
+                    "receive_code": "pass1",
+                },
+                ttl_seconds=600,
+            )
+
+        hit = tg_candidate.lookup_candidate_hint_for_name(
+            "When Will Ayumu Make His Move.2022.S01E12.1080p.BluRay.Remux.mkv",
+            media_type="tv",
+            season_number=1,
+        )
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit["tmdb_id"], "116168")
+        self.assertEqual(hit["identify_title"], "即使如此依旧步步逼近")
+
+    def test_remember_candidate_hint_refreshes_strong_keys_after_hdhive_unlock(self):
+        with mock.patch.object(
+            tg_candidate,
+            "_fetch_tmdb_alias_titles",
+            return_value=["When Will Ayumu Make His Move"],
+        ):
+            tg_candidate.remember_candidate_hint(
+                {
+                    "tmdb_id": "116168",
+                    "identify_title": "即使如此依旧步步逼近",
+                    "clean_title": "即使如此依旧步步逼近",
+                    "media_type": "tv",
+                    "confidence": "high",
+                    "target_link": "https://hdhive.com/resource/115/bee53dc13fd94156919ac43eed672087",
+                },
+                ttl_seconds=600,
+            )
+            tg_candidate.remember_candidate_hint(
+                {
+                    "tmdb_id": "116168",
+                    "identify_title": "即使如此依旧步步逼近",
+                    "clean_title": "即使如此依旧步步逼近",
+                    "media_type": "tv",
+                    "confidence": "high",
+                    "target_link": "https://115.com/s/shareayumu?password=pass1",
+                    "receive_code": "pass1",
+                },
+                ttl_seconds=600,
+            )
+
+        hit = tg_candidate.lookup_candidate_hint(
+            "When Will Ayumu Make His Move.2022.S01E12.1080p.BluRay.Remux.mkv",
+            media_type="tv",
+            lookup_key="sharepwd:shareayumu:pass1",
+        )
+        self.assertIsNotNone(hit)
+        self.assertEqual(hit["tmdb_id"], "116168")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/handler/tg_userbot.py
+++ b/handler/tg_userbot.py
@@ -1095,6 +1095,19 @@ def _process_tg_queue():
                                         pwd_match = re.search(r'(?:pwd|password|code)=([a-zA-Z0-9]+)', full_url + "&" + real_url, re.IGNORECASE)
                                         if pwd_match:
                                             receive_code = pwd_match.group(1)
+
+                                    if candidate_hints:
+                                        candidate_hints = dict(candidate_hints)
+                                        candidate_hints['target_link'] = real_url
+                                        candidate_hints['receive_code'] = receive_code or candidate_hints.get('receive_code')
+                                        remember_candidate_hint(candidate_hints)
+
+                                    if candidate:
+                                        candidate['target_link'] = real_url
+                                        candidate['receive_code'] = receive_code or candidate.get('receive_code')
+                                        task['candidate'] = candidate
+                                    task['target_link'] = real_url
+                                    task['receive_code'] = receive_code or task.get('receive_code', '')
                                             
                                     logger.debug(f"  ➜ [频道监听] 影巢 API 解析成功！真实 Share Code: {share_code}, 密码: {receive_code or '无'}")
                                 else:


### PR DESCRIPTION
## Summary / 摘要

This PR fixes a recognition gap exposed by Telegram channel imports backed by HDHive resources.

本 PR 修复了一类由 TG 频道资源 + HDHive 解锁链路暴露出来的识别问题。

A real failure case showed:
- the original TG message already contained a valid `TMDB` ID
- transfer succeeded
- but the later 115 scan still fell back to dirty filename recognition
- and finally moved the file into the unrecognized folder

一个真实失败案例表明：
- TG 原始消息里已经带有有效的 `TMDB` ID
- 转存本身成功
- 但后续 115 扫描阶段没有重新接住这条 TG hint
- 最终退回到脏文件名识别，并被打入未识别目录

## What is fixed / 本次修复内容

### 1. Refresh TG hint after HDHive unlock / HDHive 解锁后刷新 TG hint

After HDHive unlock resolves the real 115 share link, the code now re-registers the Telegram candidate hint with the resolved 115 share URL and password.

当 HDHive 解锁出真实 115 分享链接后，代码现在会基于真实的 115 share URL 和 password 重新写入 TG candidate hint。

This makes downstream lookup use stronger 115-side keys instead of only the original HDHive resource URL.

这样后续扫描链路可以优先使用更稳定的 115 强键，而不是只依赖最初的 HDHive 资源链接。

### 2. Remember TMDb alias titles for high-confidence TG hints / 为高置信 TG hint 记住 TMDb 官方别名标题

High-confidence TG hints with a valid `tmdb_id` now also remember TMDb alias titles.

高置信且带 `tmdb_id` 的 TG hint 现在会额外记住 TMDb 官方别名标题。

This helps reconnect:
- Chinese TG source title
- English release filename on disk

这样可以更好地桥接：
- TG 原文里的中文标题
- 115 落盘后的英文发布文件名

### 3. Improve noisy anime/TV filename normalization / 增强番剧与剧集噪声文件名清洗

Improved `_clean_rule_title(...)` normalization for noisy anime / TV releases.

增强了 `_clean_rule_title(...)` 对噪声番剧/剧集文件名的清洗能力。

Handled cases include:
- full-width punctuation like `？`
- codec residue like `H.264` / `H.265`
- audio residue like `FLAC 2.0`
- trailing release-group suffixes like `-AnimeF@ADE`

覆盖的噪声包括：
- 全角标点，例如 `？`
- 编码尾巴，例如 `H.264` / `H.265`
- 音频尾巴，例如 `FLAC 2.0`
- 发布组尾巴，例如 `-AnimeF@ADE`

## Why / 原因

The previous flow could still fail in this pattern:

此前链路在以下场景下仍可能失败：

1. TG candidate was recorded before HDHive unlock resolved the real 115 share link  
   TG candidate 在 HDHive 解锁真实 115 链接之前就已写入

2. Later 115 scan could not reliably reconnect the hint  
   后续 115 扫描无法稳定重新命中这条 hint

3. Fallback filename parsing still produced a noisy title  
   文件名兜底解析仍会生成带噪声的标题

This PR keeps the existing workflow and only fixes the handoff + normalization gap.

本 PR 不重构现有流程，只修复“hint 透传”和“文件名清洗”这两个缺口。

## Scope / 范围

Included / 包含：
- `handler/tg_userbot.py`
- `handler/tg_media_candidate.py`
- `handler/p115_service.py`
- related fixture / unittest updates
- 相关匿名样例与单测更新

Not included / 不包含：
- DB schema changes / 数据库结构改动
- UI changes / UI 改动
- automatic training / 自动训练
- rule approval workflow / 规则审批系统
- TG listener / reconnect redesign / TG 监听或重连机制重构
- MoviePilot workflow redesign / MoviePilot 主链重构

## Validation / 验证

Validated with:

已通过以下验证：

- `python -m py_compile handler/tg_media_candidate.py handler/tg_userbot.py handler/telegram.py handler/moviepilot.py handler/p115_service.py routes/subscription.py tasks/subscriptions.py tasks/p115.py handler/tg_media_candidate_flow.py`
- `python -m unittest handler.p115_media_recognition handler.tg_media_candidate_flow -v`
- `grep -R --exclude-dir='__pycache__' --binary-files=without-match "/Users/paysen" -n .`
- `git diff --check`

Result:
- tests passed
- no personal path leakage
- diff hygiene passed

结果：
- 单测通过
- 无个人路径泄露
- diff 卫生检查通过

## Example case / 示例案例

Example noisy filename handled by this PR:

本 PR 覆盖的一个典型噪声样例：

`When Will Ayumu Make His Move？.2022.S01E12.1080p.BluRay.Remux.H.264.FLAC 2.0-AnimeF@ADE.mkv`

The normalized title now becomes:

清洗后的标题现在可稳定变为：

`When Will Ayumu Make His Move`
