### PR TITLE
修复媒体任务繁忙时 Webhook 入库任务直接丢弃的问题

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -47,6 +47,8 @@ WEBHOOK_BATCH_QUEUE = collections.deque()
 WEBHOOK_BATCH_LOCK = threading.Lock()
 WEBHOOK_BATCH_DEBOUNCE_TIME = 30
 WEBHOOK_BATCH_DEBOUNCER = None
+WEBHOOK_TASK_RETRY_DELAY = 8
+WEBHOOK_TASK_MAX_RETRIES = 3
 
 UPDATE_DEBOUNCE_TIMERS = {}
 UPDATE_DEBOUNCE_LOCK = threading.Lock()
@@ -62,6 +64,47 @@ SYNDROME_API_LOCK = Semaphore(1)
 # --- MP 单文件上传智能合并缓冲池 ---
 MP_BATCH_QUEUE = {}
 MP_BATCH_LOCK = threading.Lock()
+
+
+def _submit_webhook_media_task(
+    task_name,
+    *,
+    retry_count=0,
+    task_function=None,
+    processor_type='media',
+    **kwargs,
+):
+    task_function = task_function or _handle_full_processing_flow
+    submitted = task_manager.submit_task(
+        task_function,
+        task_name=task_name,
+        processor_type=processor_type,
+        **kwargs,
+    )
+    if submitted:
+        if retry_count > 0:
+            logger.info(f"  ➜ [Webhook重试] 任务 '{task_name}' 第 {retry_count} 次延迟重试后提交成功。")
+        return True
+
+    if retry_count >= WEBHOOK_TASK_MAX_RETRIES:
+        logger.warning(f"  ➜ [Webhook重试] 任务 '{task_name}' 多次重试后仍提交失败，放弃。")
+        return False
+
+    next_retry = retry_count + 1
+    logger.info(
+        f"  ➜ [Webhook重试] 任务 '{task_name}' 因媒体任务繁忙延迟 {WEBHOOK_TASK_RETRY_DELAY} 秒后重试 "
+        f"(第 {next_retry}/{WEBHOOK_TASK_MAX_RETRIES} 次)。"
+    )
+    spawn_later(
+        WEBHOOK_TASK_RETRY_DELAY,
+        _submit_webhook_media_task,
+        task_name,
+        retry_count=next_retry,
+        task_function=task_function,
+        processor_type=processor_type,
+        **kwargs,
+    )
+    return False
 
 def _flush_mp_batch(key):
     """缓冲结束，将收集到的同集视频和字幕打包送入核心处理"""
@@ -646,12 +689,10 @@ def _process_batch_webhook_events():
         
         logger.info(f"  ➜ 为 '{parent_name}' 分派任务: {task_name_prefix} (分集数: {len(episode_ids)})")
         
-        task_manager.submit_task(
-            _handle_full_processing_flow,
-            task_name=f"{task_name_prefix}: {parent_name}",
-            processor_type='media', # 确保传递 processor 实例
+        _submit_webhook_media_task(
+            f"{task_name_prefix}: {parent_name}",
             item_id=parent_id,
-            force_full_update=False, # Webhook 触发通常不需要强制深度刷新 TMDb
+            force_full_update=False,
             new_episode_ids=episode_ids if episode_ids else None,
             is_new_item=not is_already_processed
         )
@@ -711,10 +752,8 @@ def _dispatch_item(item_id, item_name, item_type):
         task_name_prefix = "Webhook追更" if is_already_processed else "Webhook入库"
         
         # 直接提交给任务管理器，不经过 WEBHOOK_BATCH_QUEUE
-        task_manager.submit_task(
-            _handle_full_processing_flow,
-            task_name=f"{task_name_prefix}: {item_name}",
-            processor_type='media',
+        _submit_webhook_media_task(
+            f"{task_name_prefix}: {item_name}",
             item_id=item_id,
             force_full_update=False,
             new_episode_ids=None,

--- a/tests/test_webhook_task_retry.py
+++ b/tests/test_webhook_task_retry.py
@@ -1,0 +1,219 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _install_test_stubs():
+    flask_mod = sys.modules.get("flask") or types.ModuleType("flask")
+
+    class _Blueprint:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def route(self, *args, **kwargs):
+            def _decorator(func):
+                return func
+
+            return _decorator
+
+    flask_mod.Blueprint = _Blueprint
+    flask_mod.request = types.SimpleNamespace(get_json=lambda silent=False: {})
+    flask_mod.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    sys.modules["flask"] = flask_mod
+
+    gevent_mod = sys.modules.get("gevent") or types.ModuleType("gevent")
+    gevent_mod.spawn_later = lambda *args, **kwargs: None
+    gevent_mod.spawn = lambda *args, **kwargs: None
+    gevent_mod.sleep = lambda *args, **kwargs: None
+    sys.modules["gevent"] = gevent_mod
+
+    gevent_event_mod = sys.modules.get("gevent.event") or types.ModuleType("gevent.event")
+
+    class _Event:
+        def set(self):
+            pass
+
+        def wait(self, timeout=None):
+            return True
+
+    gevent_event_mod.Event = _Event
+    sys.modules["gevent.event"] = gevent_event_mod
+
+    gevent_lock_mod = sys.modules.get("gevent.lock") or types.ModuleType("gevent.lock")
+
+    class _Semaphore:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    gevent_lock_mod.Semaphore = _Semaphore
+    sys.modules["gevent.lock"] = gevent_lock_mod
+
+    task_manager_mod = sys.modules.get("task_manager") or types.ModuleType("task_manager")
+    task_manager_mod.submit_task = lambda *args, **kwargs: True
+    sys.modules["task_manager"] = task_manager_mod
+
+    emby_mod = sys.modules.get("handler.emby") or types.ModuleType("handler.emby")
+    emby_mod.get_series_id_from_child_id = lambda *args, **kwargs: None
+    emby_mod.get_emby_item_details = lambda *args, **kwargs: {}
+    emby_mod.add_tags_to_item = lambda *args, **kwargs: None
+    emby_mod.get_user_details = lambda *args, **kwargs: None
+    sys.modules["handler.emby"] = emby_mod
+
+    telegram_mod = sys.modules.get("handler.telegram") or types.ModuleType("handler.telegram")
+    telegram_mod.send_playback_notification = lambda *args, **kwargs: None
+    sys.modules["handler.telegram"] = telegram_mod
+
+    config_manager_mod = sys.modules.get("config_manager") or types.ModuleType("config_manager")
+    config_manager_mod.APP_CONFIG = {}
+    sys.modules["config_manager"] = config_manager_mod
+
+    constants_mod = sys.modules.get("constants") or types.ModuleType("constants")
+    constants_mod.CONFIG_OPTION_TELEGRAM_NOTIFY_TYPES = "telegram_notify_types"
+    constants_mod.DEFAULT_TELEGRAM_NOTIFY_TYPES = []
+    constants_mod.CONFIG_OPTION_115_ENABLE_SYNC_DELETE = "enable_sync_delete"
+    sys.modules["constants"] = constants_mod
+
+    extensions_mod = sys.modules.get("extensions") or types.ModuleType("extensions")
+    extensions_mod.SYSTEM_UPDATE_MARKERS = {}
+    extensions_mod.SYSTEM_UPDATE_LOCK = mock.MagicMock()
+    extensions_mod.RECURSION_SUPPRESSION_WINDOW = 60
+    extensions_mod.DELETING_COLLECTIONS = set()
+    extensions_mod.UPDATING_IMAGES = set()
+    extensions_mod.UPDATING_METADATA = set()
+    extensions_mod.media_processor_instance = types.SimpleNamespace(
+        processed_items_cache={},
+        emby_url="http://emby",
+        emby_api_key="key",
+        emby_user_id="user",
+    )
+    extensions_mod.processor_ready_required = lambda func: func
+    sys.modules["extensions"] = extensions_mod
+
+    core_processor_mod = sys.modules.get("core_processor") or types.ModuleType("core_processor")
+    core_processor_mod.MediaProcessor = object
+    sys.modules["core_processor"] = core_processor_mod
+
+    watchlist_mod = sys.modules.get("tasks.watchlist") or types.ModuleType("tasks.watchlist")
+    watchlist_mod.task_process_watchlist = lambda *args, **kwargs: None
+    sys.modules["tasks.watchlist"] = watchlist_mod
+
+    users_mod = sys.modules.get("tasks.users") or types.ModuleType("tasks.users")
+    users_mod.task_auto_sync_template_on_policy_change = lambda *args, **kwargs: None
+    sys.modules["tasks.users"] = users_mod
+
+    media_mod = sys.modules.get("tasks.media") or types.ModuleType("tasks.media")
+    media_mod.task_sync_all_metadata = lambda *args, **kwargs: None
+    sys.modules["tasks.media"] = media_mod
+
+    custom_collection_mod = sys.modules.get("handler.custom_collection") or types.ModuleType("handler.custom_collection")
+    custom_collection_mod.RecommendationEngine = object
+    sys.modules["handler.custom_collection"] = custom_collection_mod
+
+    tmdb_collections_mod = sys.modules.get("handler.tmdb_collections") or types.ModuleType("handler.tmdb_collections")
+    sys.modules["handler.tmdb_collections"] = tmdb_collections_mod
+
+    cover_generator_mod = sys.modules.get("services.cover_generator") or types.ModuleType("services.cover_generator")
+    cover_generator_mod.CoverGeneratorService = object
+    sys.modules["services.cover_generator"] = cover_generator_mod
+
+    database_pkg = sys.modules.get("database") or types.ModuleType("database")
+    for name in [
+        "custom_collection_db",
+        "tmdb_collection_db",
+        "settings_db",
+        "user_db",
+        "maintenance_db",
+        "media_db",
+        "queries_db",
+        "watchlist_db",
+    ]:
+        mod = sys.modules.get(f"database.{name}") or types.ModuleType(f"database.{name}")
+        if name == "media_db":
+            mod.is_emby_id_in_library = lambda *args, **kwargs: False
+        if name == "watchlist_db":
+            mod.get_watching_tmdb_ids = lambda: []
+        if name == "queries_db":
+            mod._expand_rating_labels = lambda value: value
+        if name == "user_db":
+            mod.upsert_emby_users_batch = lambda *args, **kwargs: None
+            mod.upsert_user_media_data = lambda *args, **kwargs: None
+        setattr(database_pkg, name, mod)
+        sys.modules[f"database.{name}"] = mod
+    sys.modules["database"] = database_pkg
+
+    database_connection_mod = sys.modules.get("database.connection") or types.ModuleType("database.connection")
+    database_connection_mod.get_db_connection = lambda: None
+    sys.modules["database.connection"] = database_connection_mod
+
+    database_log_mod = sys.modules.get("database.log_db") or types.ModuleType("database.log_db")
+    database_log_mod.LogDBManager = object
+    sys.modules["database.log_db"] = database_log_mod
+
+    p115_service_mod = sys.modules.get("handler.p115_service") or types.ModuleType("handler.p115_service")
+    p115_service_mod.P115Service = object
+    p115_service_mod.SmartOrganizer = object
+    p115_service_mod.get_config = lambda: {}
+    sys.modules["handler.p115_service"] = p115_service_mod
+
+    p115client_mod = sys.modules.get("p115client") or types.ModuleType("p115client")
+    p115client_mod.P115Client = object
+    sys.modules["p115client"] = p115client_mod
+
+
+_install_test_stubs()
+webhook = importlib.import_module("routes.webhook")
+
+
+class WebhookTaskRetryTests(unittest.TestCase):
+    def test_busy_worker_schedules_retry(self):
+        with mock.patch.object(webhook.task_manager, "submit_task", return_value=False) as submit_mock:
+            with mock.patch.object(webhook, "spawn_later") as spawn_later_mock:
+                result = webhook._submit_webhook_media_task(
+                    "Webhook入库: Test",
+                    task_function=lambda **kwargs: None,
+                    item_id="123",
+                )
+        self.assertFalse(result)
+        submit_mock.assert_called_once()
+        spawn_later_mock.assert_called_once()
+        self.assertEqual(spawn_later_mock.call_args.args[0], webhook.WEBHOOK_TASK_RETRY_DELAY)
+        self.assertIs(spawn_later_mock.call_args.args[1], webhook._submit_webhook_media_task)
+        self.assertEqual(spawn_later_mock.call_args.args[2], "Webhook入库: Test")
+        self.assertEqual(spawn_later_mock.call_args.kwargs["retry_count"], 1)
+
+    def test_retry_stops_after_max_attempts(self):
+        with mock.patch.object(webhook.task_manager, "submit_task", return_value=False):
+            with mock.patch.object(webhook, "spawn_later") as spawn_later_mock:
+                result = webhook._submit_webhook_media_task(
+                    "Webhook入库: Test",
+                    retry_count=webhook.WEBHOOK_TASK_MAX_RETRIES,
+                    task_function=lambda **kwargs: None,
+                    item_id="123",
+                )
+        self.assertFalse(result)
+        spawn_later_mock.assert_not_called()
+
+    def test_retry_success_logs_and_returns_true(self):
+        with mock.patch.object(webhook.task_manager, "submit_task", return_value=True) as submit_mock:
+            with mock.patch.object(webhook.logger, "info") as logger_mock:
+                result = webhook._submit_webhook_media_task(
+                    "Webhook入库: Test",
+                    retry_count=1,
+                    task_function=lambda **kwargs: None,
+                    item_id="123",
+                )
+        self.assertTrue(result)
+        submit_mock.assert_called_once()
+        logger_mock.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

这个 PR 修复了一个调度层问题：当 `media` 后台任务正在运行时，新的 Emby Webhook 媒体入库任务会因为 `task_manager.submit_task(...)` 拿不到全局任务锁而直接提交失败，导致任务丢失。

从实际运行日志看，`115网盘整理(TG触发)` 执行期间，电影类 `Webhook入库` 任务会直接命中：

- `任务 'Webhook入库: xxx' 提交失败：已有任务正在运行。`

本 PR 不调整现有单 worker / 全局互斥模型，只对 Webhook 媒体任务增加一个轻量的延迟重试机制，避免忙时瞬时撞锁就直接丢单。

## 根因

当前逻辑中：

- `task_manager.submit_task(...)` 对 `media` 任务使用全局非阻塞锁
- 如果已有媒体任务在运行，会直接返回 `False`
- 电影类 Webhook 走的是直接提交路径，不经过缓冲或补偿重试

因此当以下场景出现时：

1. `115网盘整理(TG触发)` 正在运行
2. Emby 同时推送电影入库 Webhook

新的 Webhook 任务会直接提交失败，而不是等待或重试。

## 本次修改

### 1. 为 Webhook 媒体任务增加统一提交封装

在 `routes/webhook.py` 中新增 `_submit_webhook_media_task(...)`，封装 Webhook 媒体任务的提交行为。

行为如下：

- 如果 `submit_task(...)` 成功，保持原逻辑
- 如果因为 worker 忙而提交失败：
  - 延迟 `8` 秒后重试
  - 最多重试 `3` 次
- 如果达到重试上限仍失败，才记录放弃日志

### 2. 替换两个实际会丢单的生产提交点

本 PR 只替换 Webhook 媒体任务的提交点：

- 电影直提交流程 `_dispatch_item(...)`
- 批量 Webhook 分派流程 `_process_batch_webhook_events(...)`

没有修改：

- `task_manager` 的全局锁实现
- TG 整理任务提交逻辑
- MoviePilot / TMDb / p115 识别链
- 数据库、UI、自动训练等其他系统

## 为什么这样改

这次修复刻意保持范围很小：

- 不重构任务系统
- 不把所有 `media` 任务都改成排队模型
- 不改变现有串行执行的总体设计

只是让 `Webhook入库 / Webhook追更` 在 worker 繁忙时不要直接丢掉，而是做一个短时间、有限次数的延迟重试。

这样风险更小，也更容易验证。

## 验证

已执行：

```bash
python -m py_compile routes/webhook.py task_manager.py tests/test_webhook_task_retry.py
python -m unittest tests.test_webhook_task_retry -v
python -m unittest handler.p115_media_recognition handler.tg_media_candidate_flow -v
git diff --check
```

结果：

- 新增 webhook 重试单测通过
- 现有 TG candidate / p115 规则识别测试仍通过
- diff 卫生检查通过

## 测试覆盖

新增测试覆盖：

- worker 忙时会安排延迟重试
- 达到最大重试次数后停止继续调度
- 重试成功时返回成功结果

## 范围边界

本 PR 不包含：

- 数据库结构改动
- UI 改动
- TG / p115 / MoviePilot 识别链改造
- 任务系统整体重构
- 把全局 `media` worker 改成真正排队模型

如果后续要继续优化，可以再单独讨论是否需要把 `media` 任务从“忙时拒绝”升级为“串行排队”。
