### PR TITLE
通知：为转存与入库消息补充季集信息

### DIFF
--- a/handler/telegram.py
+++ b/handler/telegram.py
@@ -4,6 +4,7 @@ import threading
 import extensions
 import requests
 import logging
+import re
 from datetime import datetime
 from config_manager import APP_CONFIG, get_proxies_for_requests
 from handler.emby import get_emby_item_details
@@ -13,6 +14,8 @@ import constants
 from handler.tg_media_candidate import build_channel_task_payload
 
 logger = logging.getLogger(__name__)
+
+_EPISODE_REF_PATTERN = re.compile(r'(?i)S(\d{1,3})\s*E(\d{1,4})(?:\s*-\s*E?(\d{1,4}))?')
 
 def _format_episode_ranges(episode_list: list) -> str:
     """
@@ -64,6 +67,79 @@ def _format_episode_ranges(episode_list: list) -> str:
             
     return ", ".join(final_parts)
 
+
+def _extract_episode_refs_from_text(text: str) -> list:
+    """从待复核原因等文本里提取季集引用，支持 S1E1 / S01E01-E03。"""
+    if not isinstance(text, str) or not text.strip():
+        return []
+
+    matches = []
+    for season_str, start_str, end_str in _EPISODE_REF_PATTERN.findall(text):
+        try:
+            season = int(season_str)
+            start_ep = int(start_str)
+            end_ep = int(end_str) if end_str else start_ep
+        except Exception:
+            continue
+
+        if season <= 0 or start_ep <= 0 or end_ep <= 0:
+            continue
+        if end_ep < start_ep:
+            start_ep, end_ep = end_ep, start_ep
+
+        # 防御性限制，避免异常文本把通知撑爆。
+        if end_ep - start_ep > 500:
+            end_ep = start_ep
+
+        for episode in range(start_ep, end_ep + 1):
+            matches.append((season, episode))
+
+    # 保持原始顺序去重，方便后续格式化为连续区间。
+    seen = set()
+    result = []
+    for item in matches:
+        if item in seen:
+            continue
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def _build_episode_notice_text(episode_list: list, label: str = "🎞️ *集数*") -> str:
+    """格式化通知中的季集文本，并在过长时压缩为摘要，避免 Telegram caption 过长。"""
+    normalized = []
+    seen = set()
+    for season, episode in episode_list or []:
+        try:
+            season = int(season)
+            episode = int(episode)
+        except Exception:
+            continue
+        if season <= 0 or episode <= 0:
+            continue
+        key = (season, episode)
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(key)
+
+    if not normalized:
+        return ""
+
+    formatted = _format_episode_ranges(normalized)
+    if not formatted:
+        return ""
+
+    if len(formatted) > 72:
+        season_count = len({season for season, _ in normalized})
+        episode_count = len(normalized)
+        parts = formatted.split(", ")
+        head = ", ".join(parts[:3])
+        suffix = f"等{season_count}季{episode_count}集"
+        formatted = f"{head} ... {suffix}" if head else suffix
+
+    return f"{label}: `{_markdown_code_text(formatted)}`\n"
+
 def escape_markdown(text: str) -> str:
     """
     Helper function to escape characters for Telegram's MarkdownV2.
@@ -112,6 +188,101 @@ def _notice_asset_list(value) -> list:
         return [value]
     if isinstance(value, list):
         return [item for item in value if isinstance(item, dict)]
+    return []
+
+
+def _load_episode_refs_by_emby_ids(emby_item_ids: list) -> list:
+    """从数据库回退查询分集季号/集号，避免通知强依赖 Emby 实时详情。"""
+    refs = []
+    seen = set()
+    normalized_ids = []
+    for value in emby_item_ids or []:
+        value = str(value or '').strip()
+        if value and value not in seen:
+            seen.add(value)
+            normalized_ids.append(value)
+
+    if not normalized_ids:
+        return refs
+
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor() as cursor:
+                for emby_item_id in normalized_ids:
+                    cursor.execute(
+                        """
+                        SELECT season_number, episode_number
+                        FROM media_metadata
+                        WHERE item_type = 'Episode'
+                          AND emby_item_ids_json @> %s::jsonb
+                        ORDER BY in_library DESC, date_added DESC NULLS LAST
+                        LIMIT 1
+                        """,
+                        (json.dumps([emby_item_id], ensure_ascii=False),),
+                    )
+                    row = cursor.fetchone()
+                    if not row:
+                        continue
+                    season = row.get('season_number')
+                    episode = row.get('episode_number')
+                    try:
+                        season = int(season)
+                        episode = int(episode)
+                    except Exception:
+                        continue
+                    if season > 0 and episode > 0:
+                        refs.append((season, episode))
+    except Exception as e:
+        logger.debug(f"  ➜ [通知] 数据库回退查询剧集季集失败: {e}")
+
+    return refs
+
+
+def _load_series_inventory_episode_refs(parent_series_tmdb_id: str, limit: int = 2000) -> list:
+    """读取整部剧当前在库的分集，用于普通入库通知回退展示季集范围。"""
+    parent_series_tmdb_id = str(parent_series_tmdb_id or '').strip()
+    if not parent_series_tmdb_id:
+        return []
+
+    refs = []
+    try:
+        with get_db_connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT season_number, episode_number
+                    FROM media_metadata
+                    WHERE parent_series_tmdb_id = %s
+                      AND item_type = 'Episode'
+                      AND in_library = TRUE
+                      AND season_number IS NOT NULL
+                      AND episode_number IS NOT NULL
+                    ORDER BY season_number ASC, episode_number ASC
+                    LIMIT %s
+                    """,
+                    (parent_series_tmdb_id, limit),
+                )
+                for row in cursor.fetchall():
+                    season = row.get('season_number')
+                    episode = row.get('episode_number')
+                    try:
+                        season = int(season)
+                        episode = int(episode)
+                    except Exception:
+                        continue
+                    if season > 0 and episode > 0:
+                        refs.append((season, episode))
+    except Exception as e:
+        logger.debug(f"  ➜ [通知] 读取整剧季集库存失败: series={parent_series_tmdb_id}, err={e}")
+
+    return refs
+
+
+def _extract_episode_refs_from_values(*values) -> list:
+    for value in values:
+        refs = _extract_episode_refs_from_text(value)
+        if refs:
+            return refs
     return []
 
 
@@ -361,6 +532,7 @@ def send_media_notification(item_details: dict, notification_type: str = 'new', 
         # 媒体参数不再临时查 Emby MediaSources，直接读取 process_single_item 已写入的
         # media_metadata.asset_details_json，避免重复请求和字段口径不一致。
         episode_info_text = ""
+        raw_episodes = []
         notice_emby_item_ids = []
         if item_type == "Series" and new_episode_ids:
             emby_url = APP_CONFIG.get(constants.CONFIG_OPTION_EMBY_SERVER_URL)
@@ -368,7 +540,6 @@ def send_media_notification(item_details: dict, notification_type: str = 'new', 
             user_id = APP_CONFIG.get(constants.CONFIG_OPTION_EMBY_USER_ID)
 
             # 收集原始数据而不是直接格式化字符串，这样我们可以在格式化字符串时使用
-            raw_episodes = [] 
             for ep_id in new_episode_ids:
                 detail = get_emby_item_details(ep_id, emby_url, api_key, user_id, fields="IndexNumber,ParentIndexNumber")
                 if detail:
@@ -377,11 +548,6 @@ def send_media_notification(item_details: dict, notification_type: str = 'new', 
                     # 收集元组 (季号, 集号)
                     raw_episodes.append((season_num, episode_num))
                 notice_emby_item_ids.append(str(ep_id))
-            
-            # 调用辅助函数生成合并后的字符串
-            if raw_episodes:
-                formatted_episodes = _format_episode_ranges(raw_episodes)
-                episode_info_text = f"🎞️ *集数*: `{formatted_episodes}`\n"
         elif item_id:
             notice_emby_item_ids.append(str(item_id))
 
@@ -440,6 +606,15 @@ def send_media_notification(item_details: dict, notification_type: str = 'new', 
                 f"🔍 *原因*: {escaped_reason}\n"
                 f"💡 _请前往 WebUI 手动介入处理_"
             )
+
+        if item_type == "Series" and not raw_episodes and new_episode_ids:
+            raw_episodes = _load_episode_refs_by_emby_ids(new_episode_ids)
+        if item_type == "Series" and not raw_episodes and review_reason:
+            raw_episodes = _extract_episode_refs_from_text(review_reason)
+        if item_type == "Series" and not raw_episodes and tmdb_id:
+            raw_episodes = _load_series_inventory_episode_refs(tmdb_id)
+        if raw_episodes:
+            episode_info_text = _build_episode_notice_text(raw_episodes, label="🎞️ *集数*")
 
         # ★★★ 修改：将 review_warning 追加到 caption 尾部 ★★★
         caption = (
@@ -528,14 +703,24 @@ def send_transfer_success_notification(task: dict):
         
         season_info = ""
         if item_type == 'tv':
-            if season_number is not None:
+            candidate = task.get('candidate') if isinstance(task.get('candidate'), dict) else {}
+            parsed_refs = _extract_episode_refs_from_values(
+                candidate.get('raw_text'),
+                candidate.get('title'),
+                candidate.get('identify_title'),
+                candidate.get('clean_title'),
+                title,
+            )
+            if parsed_refs:
+                season_info = _build_episode_notice_text(parsed_refs, label="🎞️ *集数*")
+            elif season_number is not None:
                 if episode_number is not None:
                     if is_pack:
-                        season_info = f"📦 *季集*: `S{season_number:02d} 包含 {episode_number} 集`\n"
+                        season_info = f"🎞️ *季集*: `S{int(season_number):02d} 共{int(episode_number)}集`\n"
                     else:
-                        season_info = f"📦 *季集*: `S{season_number:02d}E{episode_number:02d}`\n"
+                        season_info = f"🎞️ *季集*: `S{int(season_number):02d}E{int(episode_number):02d}`\n"
                 else:
-                    season_info = f"📦 *季集*: `S{season_number:02d}`\n"
+                    season_info = f"🎞️ *季集*: `S{int(season_number):02d}`\n"
 
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         

--- a/tests/test_telegram_media_notification.py
+++ b/tests/test_telegram_media_notification.py
@@ -1,0 +1,177 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _install_test_stubs():
+    config_manager_mod = sys.modules.get("config_manager") or types.ModuleType("config_manager")
+    config_manager_mod.APP_CONFIG = {}
+    config_manager_mod.get_proxies_for_requests = lambda: None
+    sys.modules["config_manager"] = config_manager_mod
+
+    constants_mod = sys.modules.get("constants") or types.ModuleType("constants")
+    constants_mod.CONFIG_OPTION_TELEGRAM_BOT_TOKEN = "telegram_bot_token"
+    constants_mod.CONFIG_OPTION_TELEGRAM_CHANNEL_ID = "telegram_channel_id"
+    constants_mod.CONFIG_OPTION_TELEGRAM_NOTIFY_TYPES = "telegram_notify_types"
+    constants_mod.DEFAULT_TELEGRAM_NOTIFY_TYPES = []
+    constants_mod.CONFIG_OPTION_EMBY_SERVER_URL = "emby_server_url"
+    constants_mod.CONFIG_OPTION_EMBY_API_KEY = "emby_api_key"
+    constants_mod.CONFIG_OPTION_EMBY_USER_ID = "emby_user_id"
+    sys.modules["constants"] = constants_mod
+
+    extensions_mod = sys.modules.get("extensions") or types.ModuleType("extensions")
+    sys.modules["extensions"] = extensions_mod
+
+    emby_mod = sys.modules.get("handler.emby") or types.ModuleType("handler.emby")
+    emby_mod.get_emby_item_details = lambda *args, **kwargs: {}
+    sys.modules["handler.emby"] = emby_mod
+
+    tg_candidate_mod = sys.modules.get("handler.tg_media_candidate") or types.ModuleType("handler.tg_media_candidate")
+    tg_candidate_mod.build_channel_task_payload = lambda *args, **kwargs: {}
+    sys.modules["handler.tg_media_candidate"] = tg_candidate_mod
+
+    p115_service_mod = sys.modules.get("handler.p115_service") or types.ModuleType("handler.p115_service")
+    p115_service_mod.P115Service = object
+    sys.modules["handler.p115_service"] = p115_service_mod
+
+    database_pkg = sys.modules.get("database") or types.ModuleType("database")
+    for name in ["user_db", "request_db", "media_db"]:
+        mod = sys.modules.get(f"database.{name}") or types.ModuleType(f"database.{name}")
+        if name == "user_db":
+            mod.get_admin_telegram_chat_ids = lambda: []
+            mod.get_user_telegram_chat_id = lambda *args, **kwargs: None
+        elif name == "request_db":
+            mod.get_subscribers_by_tmdb_id = lambda *args, **kwargs: []
+        elif name == "media_db":
+            mod.get_notification_media_info_by_emby_id = lambda *args, **kwargs: {}
+            mod.get_notification_media_info_by_tmdb_id = lambda *args, **kwargs: {}
+        setattr(database_pkg, name, mod)
+        sys.modules[f"database.{name}"] = mod
+    sys.modules["database"] = database_pkg
+
+    database_connection_mod = sys.modules.get("database.connection") or types.ModuleType("database.connection")
+    database_connection_mod.get_db_connection = lambda: None
+    sys.modules["database.connection"] = database_connection_mod
+
+
+_install_test_stubs()
+telegram = importlib.import_module("handler.telegram")
+
+
+class _FakeCursor:
+    def __init__(self, row):
+        self._row = row
+
+    def execute(self, *args, **kwargs):
+        return None
+
+    def fetchone(self):
+        return self._row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, row):
+        self._row = row
+
+    def cursor(self):
+        return _FakeCursor(self._row)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class TelegramMediaNotificationTests(unittest.TestCase):
+    def setUp(self):
+        telegram.APP_CONFIG.clear()
+        telegram.APP_CONFIG.update(
+            {
+                telegram.constants.CONFIG_OPTION_TELEGRAM_NOTIFY_TYPES: ["library_new"],
+                telegram.constants.CONFIG_OPTION_TELEGRAM_CHANNEL_ID: "test-channel",
+            }
+        )
+
+    def test_series_library_notification_uses_inventory_fallback(self):
+        item_details = {
+            "Id": "series-2",
+            "Name": "炊事班的故事",
+            "ProductionYear": 2002,
+            "Overview": "剧情简介",
+            "Type": "Series",
+            "ProviderIds": {"Tmdb": "456"},
+        }
+
+        with mock.patch.object(telegram, "get_db_connection", return_value=_FakeConnection(None)):
+            with mock.patch.object(telegram, "_load_series_inventory_episode_refs", return_value=[(1, 1), (1, 2), (1, 3)]):
+                with mock.patch.object(telegram.media_db, "get_notification_media_info_by_emby_id", return_value={}):
+                    with mock.patch.object(telegram.request_db, "get_subscribers_by_tmdb_id", return_value=[]):
+                        with mock.patch.object(telegram.user_db, "get_admin_telegram_chat_ids", return_value=[]):
+                            with mock.patch.object(telegram, "send_telegram_photo") as send_photo_mock:
+                                with mock.patch.object(telegram, "send_telegram_message") as send_message_mock:
+                                    telegram.send_media_notification(item_details, notification_type="new", new_episode_ids=None)
+
+        send_photo_mock.assert_not_called()
+        send_message_mock.assert_called_once()
+        caption = send_message_mock.call_args.args[1]
+        self.assertIn("🎞️ *集数*: `S01E01-E03`", caption)
+
+    def test_review_reason_episode_ref_is_rendered_in_caption(self):
+        item_details = {
+            "Id": "series-1",
+            "Name": "猪猪侠",
+            "ProductionYear": 2006,
+            "Overview": "剧情简介",
+            "Type": "Series",
+            "ProviderIds": {"Tmdb": "123"},
+        }
+
+        with mock.patch.object(telegram, "get_db_connection", return_value=_FakeConnection({"reason": "缺失媒体信息: [S1E1]"})):
+            with mock.patch.object(telegram.media_db, "get_notification_media_info_by_emby_id", return_value={}):
+                with mock.patch.object(telegram.request_db, "get_subscribers_by_tmdb_id", return_value=[]):
+                    with mock.patch.object(telegram.user_db, "get_admin_telegram_chat_ids", return_value=[]):
+                        with mock.patch.object(telegram, "send_telegram_photo") as send_photo_mock:
+                            with mock.patch.object(telegram, "send_telegram_message") as send_message_mock:
+                                telegram.send_media_notification(item_details, notification_type="new", new_episode_ids=None)
+
+        send_photo_mock.assert_not_called()
+        send_message_mock.assert_called_once()
+        caption = send_message_mock.call_args.args[1]
+        self.assertIn("🎞️ *集数*: `S01E01`", caption)
+        self.assertIn("🔍 *原因*: 缺失媒体信息: \\[S1E1\\]", caption)
+
+    def test_transfer_notification_uses_candidate_episode_refs(self):
+        telegram.APP_CONFIG[telegram.constants.CONFIG_OPTION_TELEGRAM_CHANNEL_ID] = "test-channel"
+        task = {
+            "title": "赌金",
+            "year": 2026,
+            "item_type": "tv",
+            "tmdb_id": "789",
+            "candidate": {
+                "raw_text": "赌金 S01E01-E02 1080p WEB-DL",
+            },
+        }
+
+        with mock.patch.object(telegram.user_db, "get_admin_telegram_chat_ids", return_value=[]):
+            with mock.patch.object(telegram.media_db, "get_notification_media_info_by_tmdb_id", return_value={}):
+                with mock.patch.object(telegram, "send_telegram_photo") as send_photo_mock:
+                    with mock.patch.object(telegram, "send_telegram_message") as send_message_mock:
+                        telegram.send_transfer_success_notification(task)
+
+        send_photo_mock.assert_not_called()
+        send_message_mock.assert_called_once()
+        caption = send_message_mock.call_args.args[1]
+        self.assertIn("🎞️ *集数*: `S01E01-E02`", caption)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明
- 为 Telegram 入库通知补充季集展示逻辑。
- 当 `new_episode_ids` 可用时，沿用现有分集信息。
- 当 `new_episode_ids` 缺失时，回退读取数据库中的在库分集信息。
- 对于待复核场景，支持从 `缺失媒体信息: [S1E1]` 这类原因文本中提取季集。
- 为转存成功通知补充季集展示；当上游任务未显式携带季集时，回退从候选原文或标题中解析 `SxxExx` 信息。
- 新增回归测试，覆盖待复核回退、普通入库回退、转存成功回退三种场景。

## 解决的问题
- 普通剧集入库通知经常只有剧名和简介，没有明确的季/集范围。
- 待复核通知虽然原因里已有 `S1E1` 等信息，但正文未稳定展示。
- 转存成功通知对剧集资源不一定展示具体季集，排查命中资源时不够直观。

## 验证
- `python -m py_compile handler/telegram.py tests/test_telegram_media_notification.py`
- `python -m unittest tests/test_telegram_media_notification.py`
- `git diff --check`
