### PR TITLE
修复 TG 系统自动更新误报成功，并补全实际更新目标解析

### DIFF
--- a/handler/telegram.py
+++ b/handler/telegram.py
@@ -1726,18 +1726,81 @@ def _execute_task_from_tg(chat_id: str, task_key: str):
         send_telegram_message(chat_id, escape_markdown(f"❌ 无法获取 {processor_type} 处理器实例。"))
         return
 
-    send_telegram_message(chat_id, escape_markdown(f"🚀 任务已启动：*{task_description}*\n请在系统日志或任务中心查看进度。"))
+    current_version = ""
+    target_version = ""
+    update_container_name = ""
+    update_image_name = ""
+    if task_key == 'system-auto-update':
+        try:
+            from tasks.system_update import get_system_update_version_info, resolve_update_target
+            version_info = get_system_update_version_info() or {}
+            current_version = str(version_info.get('current_version') or '').strip()
+            target_version = str(version_info.get('target_version') or '').strip()
+            update_target = resolve_update_target(getattr(target_processor, 'config', {}) or {})
+            update_container_name = str(update_target.get('container_name') or '').strip()
+            update_image_name = str(update_target.get('docker_image_name') or '').strip()
+        except Exception as e:
+            logger.debug(f"  ➜ [TG交互] 获取系统更新版本信息失败: {e}")
+
+    start_lines = [f"🚀 任务已启动：*{task_description}*"]
+    if task_key == 'system-auto-update':
+        if current_version:
+            start_lines.append(f"当前版本: `{current_version}`")
+        if target_version:
+            start_lines.append(f"目标版本: `{target_version}`")
+        if update_container_name:
+            start_lines.append(f"目标容器: `{update_container_name}`")
+        if update_image_name:
+            start_lines.append(f"目标镜像: `{update_image_name}`")
+    start_lines.append("请在系统日志或任务中心查看进度。")
+    send_telegram_message(chat_id, escape_markdown("\n".join(start_lines)))
     logger.info(f"  ➜ [TG交互] 管理员 {chat_id} 触发了任务: {task_description}")
 
     # 包装执行逻辑，处理特殊参数
     def run_wrapper():
         try:
+            task_result = None
             tasks_requiring_force_flag = ['role-translation', 'enrich-aliases', 'populate-metadata']
             if task_key in tasks_requiring_force_flag:
-                task_function(target_processor, force_full_update=False)
+                task_result = task_function(target_processor, force_full_update=False)
             else:
-                task_function(target_processor)
-            
+                task_result = task_function(target_processor)
+
+            if task_key == 'system-auto-update':
+                result = task_result if isinstance(task_result, dict) else {}
+                ok = bool(result.get('ok'))
+                updated = bool(result.get('updated'))
+                message = str(result.get('message') or '').strip()
+                before_version = str(result.get('current_version') or current_version or '').strip()
+                after_version = str(result.get('target_version') or target_version or '').strip()
+
+                if not ok:
+                    fail_lines = [f"❌ 任务执行失败：*{task_description}*"]
+                    if before_version:
+                        fail_lines.append(f"当前版本: `{before_version}`")
+                    if after_version:
+                        fail_lines.append(f"目标版本: `{after_version}`")
+                    if message:
+                        fail_lines.append(f"错误信息: {message}")
+                    send_telegram_message(chat_id, escape_markdown("\n".join(fail_lines)))
+                    return
+
+                success_lines = [f"✅ 任务执行完毕：*{task_description}*"]
+                if updated:
+                    if before_version and after_version:
+                        success_lines.append(f"版本变化: `{before_version}` -> `{after_version}`")
+                    elif after_version:
+                        success_lines.append(f"更新目标版本: `{after_version}`")
+                else:
+                    if before_version:
+                        success_lines.append(f"当前版本: `{before_version}`")
+                    if after_version:
+                        success_lines.append(f"最新版本: `{after_version}`")
+                if message:
+                    success_lines.append(message)
+                send_telegram_message(chat_id, escape_markdown("\n".join(success_lines)))
+                return
+
             send_telegram_message(chat_id, escape_markdown(f"✅ 任务执行完毕：*{task_description}*"))
         except Exception as e:
             logger.error(f"  ➜ TG触发任务 '{task_description}' 失败: {e}", exc_info=True)

--- a/tasks/system_update.py
+++ b/tasks/system_update.py
@@ -2,12 +2,116 @@
 import docker
 import logging
 import os
-import json
 import time
 import task_manager
 import config_manager
-import extensions
+import constants
+import handler.github as github
 logger = logging.getLogger(__name__)
+DEFAULT_CONTAINER_NAME = 'emby-toolkit'
+DEFAULT_IMAGE_NAME_TAG = 'hbq0405/emby-toolkit:latest'
+
+
+def _clean_version_text(value, default=None):
+    text = str(value or '').strip()
+    return text or default
+
+
+def _resolve_self_container_target(client):
+    """尽量从当前运行中的容器上下文识别自身容器名和镜像名。"""
+    hostname = _clean_version_text(os.environ.get('HOSTNAME'))
+    if not hostname or not client:
+        return {}
+
+    try:
+        current_container = client.containers.get(hostname)
+    except Exception as e:
+        logger.debug(f"无法根据 HOSTNAME={hostname} 识别当前容器: {e}")
+        return {}
+
+    image_name_tag = _clean_version_text(
+        ((getattr(current_container, 'attrs', {}) or {}).get('Config') or {}).get('Image')
+    )
+    if not image_name_tag:
+        tags = list(getattr(getattr(current_container, 'image', None), 'tags', None) or [])
+        image_name_tag = _clean_version_text(tags[0] if tags else None)
+
+    return {
+        "container_name": _clean_version_text(getattr(current_container, 'name', None)),
+        "docker_image_name": image_name_tag,
+    }
+
+
+def resolve_update_target(config_source=None, docker_client=None):
+    """
+    解析系统更新目标。
+    优先级：
+    1. 显式配置
+    2. 环境变量 CONTAINER_NAME / DOCKER_IMAGE_NAME
+    3. 当前运行容器自动识别
+    4. 代码默认值
+    """
+    config_source = config_source or {}
+    app_config = getattr(config_manager, 'APP_CONFIG', {}) or {}
+
+    container_name = _clean_version_text(
+        config_source.get('container_name') or app_config.get('container_name')
+    )
+    image_name_tag = _clean_version_text(
+        config_source.get('docker_image_name') or app_config.get('docker_image_name')
+    )
+
+    env_container_name = _clean_version_text(os.environ.get('CONTAINER_NAME'))
+    env_image_name_tag = _clean_version_text(os.environ.get('DOCKER_IMAGE_NAME'))
+    if not container_name and env_container_name:
+        container_name = env_container_name
+    if not image_name_tag and env_image_name_tag:
+        image_name_tag = env_image_name_tag
+
+    client = docker_client
+    if (not container_name or not image_name_tag) and client is None:
+        try:
+            client = docker.from_env()
+        except Exception as e:
+            logger.debug(f"自动识别更新目标时无法连接 Docker: {e}")
+
+    if not container_name or not image_name_tag:
+        runtime_target = _resolve_self_container_target(client)
+        if not container_name:
+            container_name = _clean_version_text(runtime_target.get('container_name'))
+        if not image_name_tag:
+            image_name_tag = _clean_version_text(runtime_target.get('docker_image_name'))
+
+    return {
+        "container_name": container_name or DEFAULT_CONTAINER_NAME,
+        "docker_image_name": image_name_tag or DEFAULT_IMAGE_NAME_TAG,
+    }
+
+
+def get_system_update_version_info():
+    """返回当前 ETK 版本和可见的最新发布版本。"""
+    current_version = _clean_version_text(getattr(constants, 'APP_VERSION', None), '0.0.0')
+    target_version = None
+
+    try:
+        github_token = config_manager.APP_CONFIG.get(constants.CONFIG_OPTION_GITHUB_TOKEN)
+        releases = github.get_github_releases(
+            owner=constants.GITHUB_REPO_OWNER,
+            repo=constants.GITHUB_REPO_NAME,
+            token=github_token,
+            proxies=config_manager.get_proxies_for_requests(),
+        ) or []
+        if releases:
+            target_version = _clean_version_text(releases[0].get('version'))
+    except Exception as e:
+        logger.debug(f"获取最新版本信息失败，将继续执行更新检查: {e}")
+
+    return {
+        "current_version": current_version,
+        "target_version": target_version,
+    }
+
+
 def _update_process_generator(container_name, image_name_tag):
     """
     核心更新逻辑生成器。
@@ -16,48 +120,78 @@ def _update_process_generator(container_name, image_name_tag):
     client = None
     proxies_config = config_manager.get_proxies_for_requests()
     old_env = os.environ.copy()
+    version_info = get_system_update_version_info()
+    current_version = version_info.get('current_version')
+    target_version = version_info.get('target_version')
     try:
         # 设置代理环境变量，以便 docker sdk 使用
         if proxies_config and proxies_config.get('https'):
             proxy_url = proxies_config['https']
             os.environ['HTTPS_PROXY'] = proxy_url
             os.environ['HTTP_PROXY'] = proxy_url
-            yield {"status": f"检测到代理配置，将通过 {proxy_url} 拉取镜像..."}
+            yield {"status": f"检测到代理配置，将通过 {proxy_url} 拉取镜像...", "current_version": current_version, "target_version": target_version}
         
         try:
             client = docker.from_env()
         except Exception as e:
-            yield {"status": f"无法连接 Docker 守护进程: {e}", "event": "ERROR"}
+            yield {"status": f"无法连接 Docker 守护进程: {e}", "event": "ERROR", "current_version": current_version, "target_version": target_version}
             return
 
-        yield {"status": f"正在检查并拉取最新镜像: {image_name_tag}..."}
+        try:
+            target_container = client.containers.get(container_name)
+        except docker.errors.NotFound:
+            yield {
+                "status": f"错误：找不到名为 '{container_name}' 的容器，请先检查系统设置中的容器名称。",
+                "event": "ERROR",
+                "current_version": current_version,
+                "target_version": target_version,
+            }
+            return
+
+        current_image_id = _clean_version_text(getattr(getattr(target_container, 'image', None), 'id', None))
+
+        yield {"status": f"正在检查并拉取最新镜像: {image_name_tag}...", "current_version": current_version, "target_version": target_version}
         
         # 使用流式 API 拉取镜像
         try:
             stream = client.api.pull(image_name_tag, stream=True, decode=True)
-            last_line = {}
+            last_status = ''
             for line in stream:
-                last_line = line
-                # 这里可以选择性 yield 详细进度，但为了通用性，我们只在最后检查结果
-            
-            # 检查最终状态
-            final_status = last_line.get('status', '')
-            if 'Status: Image is up to date' in final_status:
-                yield {"status": "当前已是最新版本。"}
-                yield {"status": "无需更新。", "event": "DONE"}
+                if not isinstance(line, dict):
+                    continue
+                if line.get('errorDetail') or line.get('error'):
+                    error_detail = line.get('errorDetail') or {}
+                    error_msg = error_detail.get('message') or line.get('error') or '未知错误'
+                    yield {"status": f"拉取镜像失败: {error_msg}", "event": "ERROR", "current_version": current_version, "target_version": target_version}
+                    return
+                status = str(line.get('status') or '').strip()
+                if status:
+                    last_status = status
+
+            latest_image = client.images.get(image_name_tag)
+            latest_image_id = _clean_version_text(getattr(latest_image, 'id', None))
+            if not latest_image_id:
+                yield {
+                    "status": "拉取镜像后未能识别最新镜像 ID，已停止更新。",
+                    "event": "ERROR",
+                    "current_version": current_version,
+                    "target_version": target_version,
+                }
                 return
-            
-            if 'errorDetail' in last_line:
-                error_msg = f"拉取镜像失败: {last_line['errorDetail']['message']}"
-                yield {"status": error_msg, "event": "ERROR"}
+
+            if current_image_id and current_image_id == latest_image_id:
+                final_msg = "当前容器已运行最新镜像，无需更新。"
+                if last_status:
+                    final_msg = f"{final_msg} Docker 返回: {last_status}"
+                yield {"status": final_msg, "event": "NO_UPDATE", "current_version": current_version, "target_version": target_version}
                 return
 
         except Exception as e:
-            yield {"status": f"拉取镜像过程中发生异常: {e}", "event": "ERROR"}
+            yield {"status": f"拉取镜像过程中发生异常: {e}", "event": "ERROR", "current_version": current_version, "target_version": target_version}
             return
 
         # --- 核心：召唤并启动“更新器容器” ---
-        yield {"status": "镜像拉取完成，准备应用更新..."}
+        yield {"status": "镜像拉取完成，准备应用更新...", "current_version": current_version, "target_version": target_version}
 
         try:
             updater_image = "containrrr/watchtower"
@@ -66,13 +200,13 @@ def _update_process_generator(container_name, image_name_tag):
             try:
                 client.images.get(updater_image)
             except docker.errors.ImageNotFound:
-                yield {"status": f"正在拉取更新器工具: {updater_image}..."}
+                yield {"status": f"正在拉取更新器工具: {updater_image}...", "current_version": current_version, "target_version": target_version}
                 client.images.pull(updater_image)
 
             # Watchtower 命令：清理旧镜像，只运行一次，指定容器名
             command = ["--cleanup", "--run-once", container_name]
 
-            yield {"status": f"正在启动 Watchtower 更新容器 '{container_name}'..."}
+            yield {"status": f"正在启动 Watchtower 更新容器 '{container_name}'...", "current_version": current_version, "target_version": target_version}
             
             client.containers.run(
                 image=updater_image,
@@ -82,16 +216,24 @@ def _update_process_generator(container_name, image_name_tag):
                 volumes={'/var/run/docker.sock': {'bind': '/var/run/docker.sock', 'mode': 'rw'}}
             )
             
-            yield {"status": "更新指令已发送！本容器即将重启...", "event": "RESTARTING"}
-            yield {"status": "更新任务已成功交接给临时更新器。", "event": "DONE"}
-
-        except docker.errors.NotFound:
-            yield {"status": f"错误：找不到名为 '{container_name}' 的容器来更新。", "event": "ERROR"}
+            yield {
+                "status": "更新指令已发送！本容器即将重启...",
+                "event": "RESTARTING",
+                "current_version": current_version,
+                "target_version": target_version,
+            }
+            yield {
+                "status": "更新任务已成功交接给临时更新器。",
+                "event": "DONE",
+                "updated": True,
+                "current_version": current_version,
+                "target_version": target_version,
+            }
         except Exception as e_updater:
-            yield {"status": f"错误：启动临时更新器时失败: {e_updater}", "event": "ERROR"}
+            yield {"status": f"错误：启动临时更新器时失败: {e_updater}", "event": "ERROR", "current_version": current_version, "target_version": target_version}
 
     except Exception as e:
-        yield {"status": f"更新过程中发生未知错误: {str(e)}", "event": "ERROR"}
+        yield {"status": f"更新过程中发生未知错误: {str(e)}", "event": "ERROR", "current_version": current_version, "target_version": target_version}
     finally:
         # 恢复环境变量
         os.environ.clear()
@@ -102,10 +244,17 @@ def task_check_and_update_container(processor):
     【后台任务版】检查并更新容器。
     此函数适配 task_manager 的日志和进度更新方式。
     """
-    container_name = processor.config.get('container_name', 'emby-toolkit')
-    image_name_tag = processor.config.get('docker_image_name', 'hbq0405/emby-toolkit:latest')
+    update_target = resolve_update_target(getattr(processor, 'config', {}) or {})
+    container_name = update_target['container_name']
+    image_name_tag = update_target['docker_image_name']
     logger.trace(f"--- 开始执行系统更新检查 (容器: {container_name}) ---")
     task_manager.update_status_from_thread(0, "准备检查更新...")
+    result = {
+        "ok": False,
+        "updated": False,
+        "message": "",
+        **get_system_update_version_info(),
+    }
 
     # 调用生成器，消费消息并转换为日志
     generator = _update_process_generator(container_name, image_name_tag)
@@ -114,11 +263,16 @@ def task_check_and_update_container(processor):
         for event in generator:
             msg = event.get('status', '')
             evt_type = event.get('event')
+            if event.get('current_version'):
+                result['current_version'] = event.get('current_version')
+            if event.get('target_version'):
+                result['target_version'] = event.get('target_version')
             
             if evt_type == 'ERROR':
                 logger.error(f"  ➜ {msg}")
                 task_manager.update_status_from_thread(-1, f"更新失败: {msg}")
-                return
+                result.update({"ok": False, "updated": False, "message": msg, "status": "error"})
+                return result
             
             logger.info(f"  ➜ {msg}")
             
@@ -127,15 +281,30 @@ def task_check_and_update_container(processor):
                 task_manager.update_status_from_thread(30, msg)
             elif "应用更新" in msg:
                 task_manager.update_status_from_thread(80, msg)
-            elif "无需更新" in msg:
+            elif evt_type == 'NO_UPDATE':
                 task_manager.update_status_from_thread(100, "已是最新版本")
+                result.update({"ok": True, "updated": False, "message": msg, "status": "up_to_date"})
             
             if evt_type == 'RESTARTING':
                 logger.warning("  ➜ 系统即将重启以应用更新...")
                 task_manager.update_status_from_thread(100, "系统正在重启...")
+                result.update({"ok": True, "updated": True, "message": msg, "status": "restarting"})
                 # 给一点时间让日志写完
                 time.sleep(3)
+            elif evt_type == 'DONE':
+                result.update({
+                    "ok": True,
+                    "updated": bool(event.get('updated', result.get('updated'))),
+                    "message": msg,
+                    "status": "done",
+                })
                 
     except Exception as e:
         logger.error(f"更新任务异常: {e}", exc_info=True)
         task_manager.update_status_from_thread(-1, "任务异常")
+        result.update({"ok": False, "updated": False, "message": f"任务异常: {e}", "status": "exception"})
+
+    if not result.get('message'):
+        result.update({"ok": True, "updated": False, "message": "更新检查完成。", "status": "done"})
+
+    return result

--- a/tests/test_telegram_system_update_notification.py
+++ b/tests/test_telegram_system_update_notification.py
@@ -1,0 +1,130 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _install_test_stubs():
+    config_manager_mod = sys.modules.get("config_manager") or types.ModuleType("config_manager")
+    config_manager_mod.APP_CONFIG = {}
+    config_manager_mod.get_proxies_for_requests = lambda: None
+    sys.modules["config_manager"] = config_manager_mod
+
+    constants_mod = sys.modules.get("constants") or types.ModuleType("constants")
+    constants_mod.APP_VERSION = "10.2.3"
+    constants_mod.CONFIG_OPTION_TELEGRAM_BOT_TOKEN = "telegram_bot_token"
+    constants_mod.CONFIG_OPTION_TELEGRAM_CHANNEL_ID = "telegram_channel_id"
+    constants_mod.CONFIG_OPTION_TELEGRAM_NOTIFY_TYPES = "telegram_notify_types"
+    constants_mod.DEFAULT_TELEGRAM_NOTIFY_TYPES = []
+    constants_mod.CONFIG_OPTION_EMBY_SERVER_URL = "emby_server_url"
+    constants_mod.CONFIG_OPTION_EMBY_API_KEY = "emby_api_key"
+    constants_mod.CONFIG_OPTION_EMBY_USER_ID = "emby_user_id"
+    constants_mod.CONFIG_OPTION_GITHUB_TOKEN = "github_token"
+    constants_mod.GITHUB_REPO_OWNER = "hbq0405"
+    constants_mod.GITHUB_REPO_NAME = "emby-toolkit"
+    sys.modules["constants"] = constants_mod
+
+    extensions_mod = sys.modules.get("extensions") or types.ModuleType("extensions")
+    extensions_mod.media_processor_instance = types.SimpleNamespace(config={})
+    extensions_mod.watchlist_processor_instance = types.SimpleNamespace(config={})
+    extensions_mod.actor_subscription_processor_instance = types.SimpleNamespace(config={})
+    sys.modules["extensions"] = extensions_mod
+
+    emby_mod = sys.modules.get("handler.emby") or types.ModuleType("handler.emby")
+    emby_mod.get_emby_item_details = lambda *args, **kwargs: {}
+    sys.modules["handler.emby"] = emby_mod
+
+    tg_candidate_mod = sys.modules.get("handler.tg_media_candidate") or types.ModuleType("handler.tg_media_candidate")
+    tg_candidate_mod.build_channel_task_payload = lambda *args, **kwargs: {}
+    sys.modules["handler.tg_media_candidate"] = tg_candidate_mod
+
+    p115_service_mod = sys.modules.get("handler.p115_service") or types.ModuleType("handler.p115_service")
+    p115_service_mod.P115Service = object
+    sys.modules["handler.p115_service"] = p115_service_mod
+
+    github_mod = sys.modules.get("handler.github") or types.ModuleType("handler.github")
+    github_mod.get_github_releases = lambda *args, **kwargs: [{"version": "v10.2.4"}]
+    sys.modules["handler.github"] = github_mod
+
+    docker_mod = sys.modules.get("docker") or types.ModuleType("docker")
+    docker_mod.from_env = lambda: None
+    docker_mod.errors = types.SimpleNamespace(NotFound=Exception, ImageNotFound=Exception)
+    sys.modules["docker"] = docker_mod
+
+    task_manager_mod = sys.modules.get("task_manager") or types.ModuleType("task_manager")
+    task_manager_mod.update_status_from_thread = lambda *args, **kwargs: None
+    sys.modules["task_manager"] = task_manager_mod
+
+    tasks_core_mod = sys.modules.get("tasks.core") or types.ModuleType("tasks.core")
+    tasks_core_mod.get_task_registry = lambda context="all": {}
+    sys.modules["tasks.core"] = tasks_core_mod
+
+    database_pkg = sys.modules.get("database") or types.ModuleType("database")
+    for name in ["user_db", "request_db", "media_db"]:
+        mod = sys.modules.get(f"database.{name}") or types.ModuleType(f"database.{name}")
+        if name == "user_db":
+            mod.get_admin_telegram_chat_ids = lambda: []
+            mod.get_user_telegram_chat_id = lambda *args, **kwargs: None
+        elif name == "request_db":
+            mod.get_subscribers_by_tmdb_id = lambda *args, **kwargs: []
+        elif name == "media_db":
+            mod.get_notification_media_info_by_emby_id = lambda *args, **kwargs: {}
+        setattr(database_pkg, name, mod)
+        sys.modules[f"database.{name}"] = mod
+    sys.modules["database"] = database_pkg
+
+    database_connection_mod = sys.modules.get("database.connection") or types.ModuleType("database.connection")
+    database_connection_mod.get_db_connection = lambda: None
+    sys.modules["database.connection"] = database_connection_mod
+
+
+_install_test_stubs()
+telegram = importlib.import_module("handler.telegram")
+system_update = importlib.import_module("tasks.system_update")
+
+
+class TelegramSystemUpdateNotificationTests(unittest.TestCase):
+    def test_resolve_update_target_falls_back_to_env(self):
+        with mock.patch.dict("os.environ", {"CONTAINER_NAME": "etk-prod", "DOCKER_IMAGE_NAME": "hbq0405/emby-toolkit:v10.2.4"}, clear=False):
+            resolved = system_update.resolve_update_target({}, docker_client=object())
+        self.assertEqual(resolved["container_name"], "etk-prod")
+        self.assertEqual(resolved["docker_image_name"], "hbq0405/emby-toolkit:v10.2.4")
+
+    def test_system_update_tg_notification_uses_real_result_and_versions(self):
+        def fake_update_task(processor):
+            return {
+                "ok": False,
+                "updated": False,
+                "message": "无法连接 Docker 守护进程",
+                "current_version": "10.2.3",
+                "target_version": "v10.2.4",
+            }
+
+        with mock.patch.object(system_update, "get_system_update_version_info", return_value={"current_version": "10.2.3", "target_version": "v10.2.4"}):
+            with mock.patch.object(system_update, "resolve_update_target", return_value={"container_name": "etk-prod", "docker_image_name": "hbq0405/emby-toolkit:v10.2.4"}):
+                with mock.patch.object(telegram, "send_telegram_message") as send_mock:
+                    with mock.patch("handler.telegram.threading.Thread") as thread_mock:
+                        thread_mock.return_value.start.side_effect = lambda: thread_mock.call_args.kwargs["target"]()
+
+                        registry = {
+                            "system-auto-update": (fake_update_task, "系统自动更新", "media")
+                        }
+                        with mock.patch("tasks.core.get_task_registry", return_value=registry):
+                            telegram._execute_task_from_tg("10001", "system-auto-update")
+
+        self.assertEqual(send_mock.call_count, 2)
+        start_message = send_mock.call_args_list[0].args[1]
+        finish_message = send_mock.call_args_list[1].args[1]
+        self.assertIn("当前版本: \\`10\\.2\\.3\\`", start_message)
+        self.assertIn("目标版本: \\`v10\\.2\\.4\\`", start_message)
+        self.assertIn("目标容器: \\`etk\\-prod\\`", start_message)
+        self.assertIn("目标镜像: \\`hbq0405/emby\\-toolkit:v10\\.2\\.4\\`", start_message)
+        self.assertIn("❌ 任务执行失败", finish_message)
+        self.assertIn("当前版本: \\`10\\.2\\.3\\`", finish_message)
+        self.assertIn("目标版本: \\`v10\\.2\\.4\\`", finish_message)
+        self.assertIn("错误信息: 无法连接 Docker 守护进程", finish_message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明
- 修复 TG 触发“系统自动更新”时只要任务函数不抛异常就直接提示成功的问题
- 为系统更新任务补充结构化结果返回，让 TG 能区分失败、无需更新、已交接更新器三种状态
- 补充当前版本、目标版本、目标容器、目标镜像通知，便于排查更新目标是否打错
- 修复更新目标解析逻辑：优先使用显式配置，其次回退 `CONTAINER_NAME` / `DOCKER_IMAGE_NAME` 环境变量，再回退当前运行容器自动识别，最后才使用默认值
- 在真正执行 watchtower 前，先校验目标容器存在并比对当前容器镜像 ID，避免默认容器名不匹配时一直更新失败

## 验证
- `python -m py_compile handler/telegram.py tasks/system_update.py tests/test_telegram_system_update_notification.py`
- `python -m unittest tests.test_telegram_system_update_notification`
- `git diff --check`

## 与 PR56 的关系
- 本 PR 只修改 TG 任务执行通知和系统更新逻辑
- 不包含 PR56 中的入库通知/季集展示修改
- 两个 PR 可以独立 review、独立 merge，顺序无要求
