### PR TITLE
将系统自动更新默认策略切换为 Docker Helper，并补发最终更新结果通知

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -11,6 +11,52 @@ import constants # 你的常量定义
 
 logger = logging.getLogger(__name__)
 
+
+def _notify_pending_system_update_result():
+    try:
+        from tasks.system_update import consume_post_update_status
+        payload = consume_post_update_status()
+    except Exception as e:
+        logger.debug(f"读取待通知的系统更新结果失败: {e}")
+        return
+
+    if not payload:
+        return
+
+    try:
+        from database import user_db
+        from handler.telegram import send_telegram_message, escape_markdown
+    except Exception as e:
+        logger.warning(f"系统更新结果通知依赖未就绪，跳过发送: {e}")
+        return
+
+    current_version = str(payload.get("current_version") or "").strip()
+    target_version = str(payload.get("target_version") or "").strip()
+    message = str(payload.get("message") or "").strip()
+    ok = bool(payload.get("ok"))
+
+    if ok:
+        lines = ["✅ 任务执行完毕：*系统自动更新*"]
+        if current_version and target_version:
+            lines.append(f"版本变化: `{current_version}` -> `{target_version}`")
+        elif target_version:
+            lines.append(f"当前版本: `{target_version}`")
+    else:
+        lines = ["❌ 任务执行失败：*系统自动更新*"]
+        if current_version:
+            lines.append(f"当前版本: `{current_version}`")
+        if target_version:
+            lines.append(f"目标版本: `{target_version}`")
+    if message:
+        lines.append(message)
+
+    text = escape_markdown("\n".join(lines))
+    try:
+        for chat_id in set(user_db.get_admin_telegram_chat_ids() or []):
+            send_telegram_message(str(chat_id), text)
+    except Exception as e:
+        logger.warning(f"发送系统更新结果 TG 通知失败: {e}")
+
 # --- 路径和配置定义 ---
 # 这部分逻辑与配置紧密相关，所以移到这里
 APP_DATA_DIR_ENV = os.environ.get("APP_DATA_DIR")
@@ -82,6 +128,8 @@ DYNAMIC_CONFIG_DEF = {
     constants.CONFIG_OPTION_TMDB_INCLUDE_ADULT: (constants.CONFIG_SECTION_TMDB, 'boolean', False),
     constants.CONFIG_OPTION_TMDB_IMAGE_LANGUAGE_PREFERENCE: (constants.CONFIG_SECTION_TMDB, 'string', 'zh'),
     constants.CONFIG_OPTION_GITHUB_TOKEN: (constants.CONFIG_SECTION_GITHUB, 'string', ""),
+    constants.CONFIG_OPTION_SYSTEM_UPDATE_STRATEGY: (constants.CONFIG_SECTION_GITHUB, 'string', "docker_helper"),
+    constants.CONFIG_OPTION_SYSTEM_UPDATE_HELPER_IMAGE: (constants.CONFIG_SECTION_GITHUB, 'string', "hbq0405/emby-toolkit:latest"),
 
     # [DoubanAPI]
     constants.CONFIG_OPTION_DOUBAN_DEFAULT_COOLDOWN: (constants.CONFIG_SECTION_API_DOUBAN, 'float', 1.0),
@@ -285,6 +333,7 @@ def load_config():
         APP_CONFIG.update(default_dynamic_config)
 
     logger.info("  ➜ 所有配置已加载完成。")
+    _notify_pending_system_update_result()
     # 函数现在不再需要返回 is_first_run，因为这个状态只在函数内部使用
     # 但为了保持函数签名不变，我们暂时保留它
     return APP_CONFIG, is_first_run

--- a/constants.py
+++ b/constants.py
@@ -145,6 +145,8 @@ CONFIG_OPTION_TMDB_IMAGE_LANGUAGE_PREFERENCE = "tmdb_image_language_preference"
 # --- GitHub (用于版本检查) ---
 CONFIG_SECTION_GITHUB = "GitHub"
 CONFIG_OPTION_GITHUB_TOKEN = "github_token" # 用于提高API速率限制的个人访问令牌
+CONFIG_OPTION_SYSTEM_UPDATE_STRATEGY = "system_update_strategy"
+CONFIG_OPTION_SYSTEM_UPDATE_HELPER_IMAGE = "system_update_helper_image"
 
 # --- 豆瓣 API ---
 CONFIG_SECTION_API_DOUBAN = "DoubanAPI"

--- a/handler/telegram.py
+++ b/handler/telegram.py
@@ -1915,15 +1915,18 @@ def _execute_task_from_tg(chat_id: str, task_key: str):
     target_version = ""
     update_container_name = ""
     update_image_name = ""
+    update_strategy = ""
     if task_key == 'system-auto-update':
         try:
-            from tasks.system_update import get_system_update_version_info, resolve_update_target
+            from tasks.system_update import get_system_update_version_info, resolve_update_target, resolve_update_strategy
             version_info = get_system_update_version_info() or {}
             current_version = str(version_info.get('current_version') or '').strip()
             target_version = str(version_info.get('target_version') or '').strip()
             update_target = resolve_update_target(getattr(target_processor, 'config', {}) or {})
             update_container_name = str(update_target.get('container_name') or '').strip()
             update_image_name = str(update_target.get('docker_image_name') or '').strip()
+            strategy_info = resolve_update_strategy(getattr(target_processor, 'config', {}) or {})
+            update_strategy = str(strategy_info.get('strategy') or '').strip()
         except Exception as e:
             logger.debug(f"  ➜ [TG交互] 获取系统更新版本信息失败: {e}")
 
@@ -1937,6 +1940,8 @@ def _execute_task_from_tg(chat_id: str, task_key: str):
             start_lines.append(f"目标容器: `{update_container_name}`")
         if update_image_name:
             start_lines.append(f"目标镜像: `{update_image_name}`")
+        if update_strategy:
+            start_lines.append(f"更新策略: `{update_strategy}`")
     start_lines.append("请在系统日志或任务中心查看进度。")
     send_telegram_message(chat_id, escape_markdown("\n".join(start_lines)))
     logger.info(f"  ➜ [TG交互] 管理员 {chat_id} 触发了任务: {task_description}")

--- a/tasks/system_update.py
+++ b/tasks/system_update.py
@@ -1,15 +1,296 @@
-#tasks/system_update.py
-import docker
+import json
 import logging
 import os
+import tempfile
 import time
-import task_manager
+from pathlib import Path
+
+import docker
+
 import config_manager
 import constants
 import handler.github as github
+import task_manager
+
 logger = logging.getLogger(__name__)
+
 DEFAULT_CONTAINER_NAME = 'emby-toolkit'
 DEFAULT_IMAGE_NAME_TAG = 'hbq0405/emby-toolkit:latest'
+DEFAULT_UPDATE_STRATEGY = 'docker_helper'
+DEFAULT_HELPER_IMAGE = 'hbq0405/emby-toolkit:latest'
+UPDATE_STATUS_FILE = 'system_update_result.json'
+
+DOCKER_HELPER_SCRIPT = r"""
+import json
+import os
+import sys
+import time
+
+import docker
+
+STATUS_PATH = os.environ["ETK_UPDATE_STATUS_PATH"]
+TARGET_CONTAINER = os.environ["ETK_TARGET_CONTAINER"]
+TARGET_IMAGE = os.environ["ETK_TARGET_IMAGE"]
+REQUESTED_BY = os.environ.get("ETK_REQUESTED_BY", "")
+REQUEST_SOURCE = os.environ.get("ETK_REQUEST_SOURCE", "system-auto-update")
+CURRENT_VERSION = os.environ.get("ETK_CURRENT_VERSION", "")
+TARGET_VERSION = os.environ.get("ETK_TARGET_VERSION", "")
+
+
+def write_status(payload):
+    payload = dict(payload or {})
+    payload.setdefault("container_name", TARGET_CONTAINER)
+    payload.setdefault("image_name", TARGET_IMAGE)
+    payload.setdefault("requested_by", REQUESTED_BY)
+    payload.setdefault("request_source", REQUEST_SOURCE)
+    payload.setdefault("current_version", CURRENT_VERSION)
+    payload.setdefault("target_version", TARGET_VERSION)
+    payload.setdefault("timestamp", int(time.time()))
+    tmp_path = STATUS_PATH + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False)
+    os.replace(tmp_path, STATUS_PATH)
+
+
+def build_binds(host_config):
+    binds = {}
+    for item in host_config.get("Binds") or []:
+        spec = str(item or "").strip()
+        if not spec:
+            continue
+        parts = spec.split(":")
+        if len(parts) >= 3:
+            source = parts[0]
+            bind = parts[1]
+            mode = ":".join(parts[2:])
+        elif len(parts) == 2:
+            source, bind = parts
+            mode = "rw"
+        else:
+            continue
+        entry = {"bind": bind, "mode": mode}
+        if "," in mode:
+            segments = mode.split(",")
+            entry["mode"] = segments[0] or "rw"
+            if len(segments) > 1 and segments[1]:
+                entry["propagation"] = segments[1]
+        binds[source] = entry
+    return binds
+
+
+def build_port_bindings(host_config):
+    bindings = host_config.get("PortBindings") or {}
+    result = {}
+    for container_port, entries in bindings.items():
+        if not entries:
+            result[container_port] = None
+            continue
+        normalized = []
+        for item in entries:
+            host_ip = item.get("HostIp") or ""
+            host_port = item.get("HostPort") or ""
+            if host_ip and host_port:
+                normalized.append((host_ip, int(host_port)))
+            elif host_ip:
+                normalized.append((host_ip,))
+            elif host_port:
+                normalized.append(int(host_port))
+            else:
+                normalized.append(None)
+        result[container_port] = normalized[0] if len(normalized) == 1 else normalized
+    return result
+
+
+def build_restart_policy(host_config):
+    policy = host_config.get("RestartPolicy") or {}
+    name = policy.get("Name")
+    if not name:
+        return None
+    return {
+        "Name": name,
+        "MaximumRetryCount": int(policy.get("MaximumRetryCount") or 0),
+    }
+
+
+def build_networking(client, container_attrs):
+    host_config = container_attrs.get("HostConfig") or {}
+    network_mode = host_config.get("NetworkMode") or "default"
+    network_settings = (container_attrs.get("NetworkSettings") or {}).get("Networks") or {}
+    networking_config = None
+
+    if network_mode not in {"host", "none", "container"} and network_settings:
+        endpoints = {}
+        for network_name, network_data in network_settings.items():
+            endpoint_kwargs = {}
+            aliases = list(network_data.get("Aliases") or [])
+            if aliases:
+                endpoint_kwargs["aliases"] = aliases
+            ipv4_address = (network_data.get("IPAMConfig") or {}).get("IPv4Address") or network_data.get("IPAddress")
+            if ipv4_address:
+                endpoint_kwargs["ipv4_address"] = ipv4_address
+            ipv6_address = (network_data.get("IPAMConfig") or {}).get("IPv6Address") or network_data.get("GlobalIPv6Address")
+            if ipv6_address:
+                endpoint_kwargs["ipv6_address"] = ipv6_address
+            endpoints[network_name] = client.api.create_endpoint_config(**endpoint_kwargs)
+        networking_config = client.api.create_networking_config(endpoints)
+
+    return network_mode, networking_config
+
+
+def collect_create_kwargs(client, container):
+    attrs = container.attrs or {}
+    config = attrs.get("Config") or {}
+    host_config = attrs.get("HostConfig") or {}
+
+    ports = list((config.get("ExposedPorts") or {}).keys()) or None
+    volumes = list((config.get("Volumes") or {}).keys()) or None
+    binds = build_binds(host_config)
+    port_bindings = build_port_bindings(host_config)
+    restart_policy = build_restart_policy(host_config)
+    network_mode, networking_config = build_networking(client, attrs)
+    healthcheck = config.get("Healthcheck")
+    host_cfg = client.api.create_host_config(
+        auto_remove=bool(host_config.get("AutoRemove")),
+        binds=binds or None,
+        cap_add=host_config.get("CapAdd"),
+        cap_drop=host_config.get("CapDrop"),
+        dns=host_config.get("Dns"),
+        dns_opt=host_config.get("DnsOptions"),
+        dns_search=host_config.get("DnsSearch"),
+        extra_hosts=host_config.get("ExtraHosts"),
+        group_add=host_config.get("GroupAdd"),
+        ipc_mode=host_config.get("IpcMode"),
+        log_config=host_config.get("LogConfig"),
+        network_mode=network_mode,
+        pid_mode=host_config.get("PidMode"),
+        pids_limit=host_config.get("PidsLimit"),
+        port_bindings=port_bindings or None,
+        privileged=bool(host_config.get("Privileged")),
+        publish_all_ports=bool(host_config.get("PublishAllPorts")),
+        read_only=bool(host_config.get("ReadonlyRootfs")),
+        restart_policy=restart_policy,
+        runtime=host_config.get("Runtime"),
+        security_opt=host_config.get("SecurityOpt"),
+        shm_size=host_config.get("ShmSize"),
+        sysctls=host_config.get("Sysctls"),
+        ulimits=host_config.get("Ulimits"),
+    )
+
+    return {
+        "image": TARGET_IMAGE,
+        "command": config.get("Cmd"),
+        "hostname": config.get("Hostname") or None,
+        "user": config.get("User") or None,
+        "detach": True,
+        "stdin_open": bool(config.get("OpenStdin")),
+        "tty": bool(config.get("Tty")),
+        "ports": ports,
+        "environment": list(config.get("Env") or []),
+        "volumes": volumes,
+        "name": container.name,
+        "entrypoint": config.get("Entrypoint"),
+        "working_dir": config.get("WorkingDir") or None,
+        "domainname": config.get("Domainname") or None,
+        "labels": dict(config.get("Labels") or {}),
+        "host_config": host_cfg,
+        "networking_config": networking_config,
+        "healthcheck": healthcheck,
+        "stop_timeout": int(config.get("StopTimeout") or 10),
+    }
+
+
+def wait_for_health(container, timeout=90):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        container.reload()
+        state = container.attrs.get("State") or {}
+        health = state.get("Health") or {}
+        status = health.get("Status")
+        if status in {None, ""}:
+            return True, "容器已启动（未配置健康检查）。"
+        if status == "healthy":
+            return True, "容器健康检查通过。"
+        if status == "unhealthy":
+            return False, "新容器健康检查失败。"
+        time.sleep(2)
+    return False, "等待新容器健康检查超时。"
+
+
+def main():
+    client = docker.from_env()
+    try:
+        container = client.containers.get(TARGET_CONTAINER)
+    except Exception as exc:
+        write_status({"ok": False, "updated": False, "message": f"helper 找不到目标容器: {exc}", "status": "error"})
+        return 1
+
+    old_container_id = container.id
+    old_image_id = (container.attrs.get("Image") or "") if container.attrs else ""
+    create_kwargs = collect_create_kwargs(client, container)
+    backup_name = f"{container.name}-backup-{int(time.time())}"
+
+    try:
+        container.stop(timeout=int((container.attrs.get("Config") or {}).get("StopTimeout") or 10))
+        container.rename(backup_name)
+        response = client.api.create_container(**create_kwargs)
+        new_container_id = response.get("Id")
+        if not new_container_id:
+            raise RuntimeError("Docker API 未返回新容器 ID。")
+        client.api.start(new_container_id)
+        new_container = client.containers.get(new_container_id)
+        healthy, message = wait_for_health(new_container)
+        if not healthy:
+            raise RuntimeError(message)
+
+        backup_container = client.containers.get(backup_name)
+        backup_container.remove(force=True)
+        new_container.reload()
+        write_status({
+            "ok": True,
+            "updated": True,
+            "message": message,
+            "status": "updated",
+            "old_container_id": old_container_id,
+            "new_container_id": new_container.id,
+            "old_image_id": old_image_id,
+            "new_image_id": new_container.attrs.get("Image") or "",
+        })
+        return 0
+    except Exception as exc:
+        try:
+            current = None
+            try:
+                current = client.containers.get(TARGET_CONTAINER)
+            except Exception:
+                current = None
+
+            if current is not None and current.id != old_container_id:
+                current.remove(force=True)
+
+            backup_container = client.containers.get(backup_name)
+            backup_container.rename(TARGET_CONTAINER)
+            backup_container.start()
+        except Exception as rollback_exc:
+            write_status({
+                "ok": False,
+                "updated": False,
+                "message": f"更新失败且回滚失败: {exc}; rollback={rollback_exc}",
+                "status": "rollback_failed",
+            })
+            return 1
+
+        write_status({
+            "ok": False,
+            "updated": False,
+            "message": f"helper 更新失败，已回滚: {exc}",
+            "status": "rolled_back",
+        })
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+"""
 
 
 def _clean_version_text(value, default=None):
@@ -17,8 +298,49 @@ def _clean_version_text(value, default=None):
     return text or default
 
 
+def _read_json_file(path):
+    try:
+        with open(path, 'r', encoding='utf-8') as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        logger.warning(f"读取 JSON 文件失败: {path}, err={e}")
+        return None
+
+
+def _write_json_file(path, payload):
+    temp_path = f"{path}.tmp"
+    with open(temp_path, 'w', encoding='utf-8') as fh:
+        json.dump(payload, fh, ensure_ascii=False)
+    os.replace(temp_path, path)
+
+
+def _get_update_status_path():
+    persistent_root = getattr(config_manager, 'PERSISTENT_DATA_PATH', None)
+    if persistent_root:
+        return os.path.join(persistent_root, UPDATE_STATUS_FILE)
+    app_data_dir = _clean_version_text(os.environ.get('APP_DATA_DIR'))
+    if app_data_dir:
+        return os.path.join(app_data_dir, UPDATE_STATUS_FILE)
+    return os.path.join(os.getcwd(), UPDATE_STATUS_FILE)
+
+
+def consume_post_update_status():
+    status_path = _get_update_status_path()
+    payload = _read_json_file(status_path)
+    if not payload:
+        return None
+    try:
+        os.remove(status_path)
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        logger.warning(f"删除更新状态文件失败: {status_path}, err={e}")
+    return payload
+
+
 def _resolve_self_container_target(client):
-    """尽量从当前运行中的容器上下文识别自身容器名和镜像名。"""
     hostname = _clean_version_text(os.environ.get('HOSTNAME'))
     if not hostname or not client:
         return {}
@@ -43,14 +365,6 @@ def _resolve_self_container_target(client):
 
 
 def resolve_update_target(config_source=None, docker_client=None):
-    """
-    解析系统更新目标。
-    优先级：
-    1. 显式配置
-    2. 环境变量 CONTAINER_NAME / DOCKER_IMAGE_NAME
-    3. 当前运行容器自动识别
-    4. 代码默认值
-    """
     config_source = config_source or {}
     app_config = getattr(config_manager, 'APP_CONFIG', {}) or {}
 
@@ -88,8 +402,28 @@ def resolve_update_target(config_source=None, docker_client=None):
     }
 
 
+def resolve_update_strategy(config_source=None):
+    config_source = config_source or {}
+    app_config = getattr(config_manager, 'APP_CONFIG', {}) or {}
+    strategy = _clean_version_text(
+        config_source.get('system_update_strategy')
+        or app_config.get('system_update_strategy')
+        or os.environ.get('SYSTEM_UPDATE_STRATEGY'),
+        DEFAULT_UPDATE_STRATEGY,
+    )
+    helper_image = _clean_version_text(
+        config_source.get('system_update_helper_image')
+        or app_config.get('system_update_helper_image')
+        or os.environ.get('SYSTEM_UPDATE_HELPER_IMAGE'),
+        DEFAULT_HELPER_IMAGE,
+    )
+    return {
+        "strategy": strategy,
+        "helper_image": helper_image,
+    }
+
+
 def get_system_update_version_info():
-    """返回当前 ETK 版本和可见的最新发布版本。"""
     current_version = _clean_version_text(getattr(constants, 'APP_VERSION', None), '0.0.0')
     target_version = None
 
@@ -112,25 +446,186 @@ def get_system_update_version_info():
     }
 
 
-def _update_process_generator(container_name, image_name_tag):
-    """
-    核心更新逻辑生成器。
-    yield 返回字典格式的状态信息: {"status": "消息内容", "event": "可选事件类型(DONE/ERROR)"}
-    """
+def _decode_container_output(output):
+    if output is None:
+        return ""
+    if isinstance(output, (bytes, bytearray)):
+        return output.decode('utf-8', errors='replace')
+    if isinstance(output, str):
+        return output
+    if isinstance(output, (list, tuple)):
+        return "\n".join(_decode_container_output(item) for item in output)
+    return str(output)
+
+
+def _read_image_label_version(image):
+    labels = ((getattr(image, 'attrs', {}) or {}).get('Config') or {}).get('Labels') or {}
+    return _clean_version_text(labels.get('org.opencontainers.image.version'))
+
+
+def _build_helper_environment(status_path, container_name, image_name_tag, version_info):
+    return {
+        "ETK_UPDATE_STATUS_PATH": status_path,
+        "ETK_TARGET_CONTAINER": container_name,
+        "ETK_TARGET_IMAGE": image_name_tag,
+        "ETK_REQUESTED_BY": "tg-or-web",
+        "ETK_REQUEST_SOURCE": "system-auto-update",
+        "ETK_CURRENT_VERSION": _clean_version_text(version_info.get('current_version')),
+        "ETK_TARGET_VERSION": _clean_version_text(version_info.get('target_version')),
+    }
+
+
+def _ensure_helper_image(client, helper_image, version_info):
+    try:
+        client.images.get(helper_image)
+    except docker.errors.ImageNotFound:
+        yield {"status": f"正在拉取更新器工具: {helper_image}...", "current_version": version_info.get('current_version'), "target_version": version_info.get('target_version')}
+        client.images.pull(helper_image)
+
+
+def _run_docker_helper(client, helper_image, container_name, image_name_tag, version_info):
+    status_path = _get_update_status_path()
+    persistent_root = os.path.dirname(status_path)
+    os.makedirs(persistent_root, exist_ok=True)
+    try:
+        os.remove(status_path)
+    except FileNotFoundError:
+        pass
+
+    for event in _ensure_helper_image(client, helper_image, version_info):
+        yield event
+
+    env = _build_helper_environment(status_path, container_name, image_name_tag, version_info)
+    with tempfile.NamedTemporaryFile('w', encoding='utf-8', suffix='.py', delete=False) as tmp_script:
+        tmp_script.write(DOCKER_HELPER_SCRIPT)
+        helper_script_path = tmp_script.name
+
+    volumes = {
+        '/var/run/docker.sock': {'bind': '/var/run/docker.sock', 'mode': 'rw'},
+        persistent_root: {'bind': persistent_root, 'mode': 'rw'},
+        helper_script_path: {'bind': '/tmp/etk_update_helper.py', 'mode': 'ro'},
+    }
+
+    yield {
+        "status": f"正在启动 Docker Helper 更新容器 '{container_name}'...",
+        "current_version": version_info.get('current_version'),
+        "target_version": version_info.get('target_version'),
+    }
+
+    try:
+        output = client.containers.run(
+            image=helper_image,
+            command=["python", "/tmp/etk_update_helper.py"],
+            remove=True,
+            detach=False,
+            environment=env,
+            volumes=volumes,
+        )
+        logger.debug(f"Docker helper 输出: {_decode_container_output(output)}")
+    except Exception as e:
+        yield {
+            "status": f"启动 Docker Helper 失败: {e}",
+            "event": "ERROR",
+            "current_version": version_info.get('current_version'),
+            "target_version": version_info.get('target_version'),
+        }
+        return
+    finally:
+        try:
+            os.remove(helper_script_path)
+        except FileNotFoundError:
+            pass
+
+    status_payload = _read_json_file(status_path)
+    if not status_payload:
+        yield {
+            "status": "Docker Helper 已退出，但未写入更新结果。",
+            "event": "ERROR",
+            "current_version": version_info.get('current_version'),
+            "target_version": version_info.get('target_version'),
+        }
+        return
+
+    if not status_payload.get('ok'):
+        yield {
+            "status": str(status_payload.get('message') or 'Docker Helper 更新失败'),
+            "event": "ERROR",
+            "current_version": _clean_version_text(status_payload.get('current_version'), version_info.get('current_version')),
+            "target_version": _clean_version_text(status_payload.get('target_version'), version_info.get('target_version')),
+        }
+        return
+
+    yield {
+        "status": "更新任务已交接给 Docker Helper，新容器启动后将补发最终结果通知。",
+        "event": "RESTARTING",
+        "updated": True,
+        "current_version": _clean_version_text(status_payload.get('current_version'), version_info.get('current_version')),
+        "target_version": _clean_version_text(status_payload.get('target_version'), version_info.get('target_version')),
+    }
+
+
+def _run_watchtower(client, container_name, version_info):
+    updater_image = "containrrr/watchtower"
+    try:
+        client.images.get(updater_image)
+    except docker.errors.ImageNotFound:
+        yield {"status": f"正在拉取更新器工具: {updater_image}...", "current_version": version_info.get('current_version'), "target_version": version_info.get('target_version')}
+        client.images.pull(updater_image)
+
+    command = ["--cleanup", "--run-once", container_name]
+    yield {
+        "status": f"正在启动 Watchtower 更新容器 '{container_name}'...",
+        "current_version": version_info.get('current_version'),
+        "target_version": version_info.get('target_version'),
+    }
+    try:
+        client.containers.run(
+            image=updater_image,
+            command=command,
+            remove=True,
+            detach=True,
+            volumes={'/var/run/docker.sock': {'bind': '/var/run/docker.sock', 'mode': 'rw'}},
+        )
+    except Exception as e:
+        yield {
+            "status": f"错误：启动 Watchtower 更新器失败: {e}",
+            "event": "ERROR",
+            "current_version": version_info.get('current_version'),
+            "target_version": version_info.get('target_version'),
+        }
+        return
+
+    yield {
+        "status": "更新指令已发送！本容器即将重启...",
+        "event": "RESTARTING",
+        "current_version": version_info.get('current_version'),
+        "target_version": version_info.get('target_version'),
+    }
+    yield {
+        "status": "更新任务已成功交接给 Watchtower。",
+        "event": "DONE",
+        "updated": True,
+        "current_version": version_info.get('current_version'),
+        "target_version": version_info.get('target_version'),
+    }
+
+
+def _update_process_generator(container_name, image_name_tag, strategy=None, helper_image=None):
     client = None
     proxies_config = config_manager.get_proxies_for_requests()
     old_env = os.environ.copy()
     version_info = get_system_update_version_info()
     current_version = version_info.get('current_version')
     target_version = version_info.get('target_version')
+    strategy_name = _clean_version_text(strategy, DEFAULT_UPDATE_STRATEGY)
+    helper_image_name = _clean_version_text(helper_image, DEFAULT_HELPER_IMAGE)
     try:
-        # 设置代理环境变量，以便 docker sdk 使用
         if proxies_config and proxies_config.get('https'):
             proxy_url = proxies_config['https']
             os.environ['HTTPS_PROXY'] = proxy_url
             os.environ['HTTP_PROXY'] = proxy_url
             yield {"status": f"检测到代理配置，将通过 {proxy_url} 拉取镜像...", "current_version": current_version, "target_version": target_version}
-        
+
         try:
             client = docker.from_env()
         except Exception as e:
@@ -149,10 +644,12 @@ def _update_process_generator(container_name, image_name_tag):
             return
 
         current_image_id = _clean_version_text(getattr(getattr(target_container, 'image', None), 'id', None))
+        if not current_version:
+            current_version = _read_image_label_version(getattr(target_container, 'image', None)) or current_version
+            version_info['current_version'] = current_version
 
         yield {"status": f"正在检查并拉取最新镜像: {image_name_tag}...", "current_version": current_version, "target_version": target_version}
-        
-        # 使用流式 API 拉取镜像
+
         try:
             stream = client.api.pull(image_name_tag, stream=True, decode=True)
             last_status = ''
@@ -179,85 +676,68 @@ def _update_process_generator(container_name, image_name_tag):
                 }
                 return
 
+            version_info['target_version'] = _read_image_label_version(latest_image) or target_version
+
             if current_image_id and current_image_id == latest_image_id:
                 final_msg = "当前容器已运行最新镜像，无需更新。"
                 if last_status:
                     final_msg = f"{final_msg} Docker 返回: {last_status}"
-                yield {"status": final_msg, "event": "NO_UPDATE", "current_version": current_version, "target_version": target_version}
+                yield {"status": final_msg, "event": "NO_UPDATE", "current_version": current_version, "target_version": version_info.get('target_version')}
                 return
 
         except Exception as e:
             yield {"status": f"拉取镜像过程中发生异常: {e}", "event": "ERROR", "current_version": current_version, "target_version": target_version}
             return
 
-        # --- 核心：召唤并启动“更新器容器” ---
-        yield {"status": "镜像拉取完成，准备应用更新...", "current_version": current_version, "target_version": target_version}
+        yield {
+            "status": f"镜像拉取完成，准备通过 `{strategy_name}` 应用更新...",
+            "current_version": current_version,
+            "target_version": version_info.get('target_version'),
+        }
 
-        try:
-            updater_image = "containrrr/watchtower"
-            
-            # 确保 watchtower 镜像存在
-            try:
-                client.images.get(updater_image)
-            except docker.errors.ImageNotFound:
-                yield {"status": f"正在拉取更新器工具: {updater_image}...", "current_version": current_version, "target_version": target_version}
-                client.images.pull(updater_image)
+        if strategy_name == 'watchtower':
+            for event in _run_watchtower(client, container_name, version_info):
+                yield event
+            return
 
-            # Watchtower 命令：清理旧镜像，只运行一次，指定容器名
-            command = ["--cleanup", "--run-once", container_name]
-
-            yield {"status": f"正在启动 Watchtower 更新容器 '{container_name}'...", "current_version": current_version, "target_version": target_version}
-            
-            client.containers.run(
-                image=updater_image,
-                command=command,
-                remove=True,
-                detach=True,
-                volumes={'/var/run/docker.sock': {'bind': '/var/run/docker.sock', 'mode': 'rw'}}
-            )
-            
+        if strategy_name != 'docker_helper':
             yield {
-                "status": "更新指令已发送！本容器即将重启...",
-                "event": "RESTARTING",
+                "status": f"未支持的系统更新策略: {strategy_name}",
+                "event": "ERROR",
                 "current_version": current_version,
-                "target_version": target_version,
+                "target_version": version_info.get('target_version'),
             }
-            yield {
-                "status": "更新任务已成功交接给临时更新器。",
-                "event": "DONE",
-                "updated": True,
-                "current_version": current_version,
-                "target_version": target_version,
-            }
-        except Exception as e_updater:
-            yield {"status": f"错误：启动临时更新器时失败: {e_updater}", "event": "ERROR", "current_version": current_version, "target_version": target_version}
+            return
+
+        for event in _run_docker_helper(client, helper_image_name, container_name, image_name_tag, version_info):
+            yield event
 
     except Exception as e:
         yield {"status": f"更新过程中发生未知错误: {str(e)}", "event": "ERROR", "current_version": current_version, "target_version": target_version}
     finally:
-        # 恢复环境变量
         os.environ.clear()
         os.environ.update(old_env)
 
+
 def task_check_and_update_container(processor):
-    """
-    【后台任务版】检查并更新容器。
-    此函数适配 task_manager 的日志和进度更新方式。
-    """
     update_target = resolve_update_target(getattr(processor, 'config', {}) or {})
+    strategy_info = resolve_update_strategy(getattr(processor, 'config', {}) or {})
     container_name = update_target['container_name']
     image_name_tag = update_target['docker_image_name']
-    logger.trace(f"--- 开始执行系统更新检查 (容器: {container_name}) ---")
+    strategy_name = strategy_info['strategy']
+    helper_image = strategy_info['helper_image']
+    logger.trace(f"--- 开始执行系统更新检查 (容器: {container_name}, 策略: {strategy_name}) ---")
     task_manager.update_status_from_thread(0, "准备检查更新...")
     result = {
         "ok": False,
         "updated": False,
         "message": "",
+        "strategy": strategy_name,
+        "helper_image": helper_image,
         **get_system_update_version_info(),
     }
 
-    # 调用生成器，消费消息并转换为日志
-    generator = _update_process_generator(container_name, image_name_tag)
+    generator = _update_process_generator(container_name, image_name_tag, strategy=strategy_name, helper_image=helper_image)
 
     try:
         for event in generator:
@@ -267,30 +747,28 @@ def task_check_and_update_container(processor):
                 result['current_version'] = event.get('current_version')
             if event.get('target_version'):
                 result['target_version'] = event.get('target_version')
-            
+
             if evt_type == 'ERROR':
                 logger.error(f"  ➜ {msg}")
                 task_manager.update_status_from_thread(-1, f"更新失败: {msg}")
                 result.update({"ok": False, "updated": False, "message": msg, "status": "error"})
                 return result
-            
+
             logger.info(f"  ➜ {msg}")
-            
-            # 简单的进度模拟
+
             if "拉取" in msg:
                 task_manager.update_status_from_thread(30, msg)
-            elif "应用更新" in msg:
+            elif "应用更新" in msg or "Docker Helper" in msg or "Watchtower" in msg:
                 task_manager.update_status_from_thread(80, msg)
             elif evt_type == 'NO_UPDATE':
                 task_manager.update_status_from_thread(100, "已是最新版本")
                 result.update({"ok": True, "updated": False, "message": msg, "status": "up_to_date"})
-            
+
             if evt_type == 'RESTARTING':
                 logger.warning("  ➜ 系统即将重启以应用更新...")
                 task_manager.update_status_from_thread(100, "系统正在重启...")
                 result.update({"ok": True, "updated": True, "message": msg, "status": "restarting"})
-                # 给一点时间让日志写完
-                time.sleep(3)
+                time.sleep(1)
             elif evt_type == 'DONE':
                 result.update({
                     "ok": True,
@@ -298,7 +776,7 @@ def task_check_and_update_container(processor):
                     "message": msg,
                     "status": "done",
                 })
-                
+
     except Exception as e:
         logger.error(f"更新任务异常: {e}", exc_info=True)
         task_manager.update_status_from_thread(-1, "任务异常")

--- a/tests/test_system_update_post_notify.py
+++ b/tests/test_system_update_post_notify.py
@@ -1,0 +1,197 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _install_stubs():
+    constants_mod = sys.modules.get("constants") or types.ModuleType("constants")
+    constants_mod.CONFIG_FILE_NAME = "config.ini"
+    constants_mod.CONFIG_OPTION_DB_HOST = "db_host"
+    constants_mod.CONFIG_OPTION_DB_PORT = "db_port"
+    constants_mod.CONFIG_OPTION_DB_USER = "db_user"
+    constants_mod.CONFIG_OPTION_DB_PASSWORD = "db_password"
+    constants_mod.CONFIG_OPTION_DB_NAME = "db_name"
+    constants_mod.CONFIG_OPTION_AUTH_ENABLED = "auth_enabled"
+    constants_mod.CONFIG_OPTION_AUTH_USERNAME = "username"
+    constants_mod.DEFAULT_USERNAME = "admin"
+    constants_mod.CONFIG_SECTION_DATABASE = "Database"
+    constants_mod.CONFIG_SECTION_AUTH = "Authentication"
+    constants_mod.CONFIG_SECTION_EMBY = "Emby"
+    constants_mod.CONFIG_SECTION_REVERSE_PROXY = "ReverseProxy"
+    constants_mod.CONFIG_SECTION_TMDB = "TMDB"
+    constants_mod.CONFIG_SECTION_GITHUB = "GitHub"
+    constants_mod.CONFIG_SECTION_API_DOUBAN = "DoubanAPI"
+    constants_mod.CONFIG_SECTION_MONITOR = "Monitor"
+    constants_mod.CONFIG_SECTION_115 = "115"
+    constants_mod.CONFIG_SECTION_NETWORK = "Network"
+    constants_mod.CONFIG_SECTION_AI_TRANSLATION = "AITranslation"
+    constants_mod.CONFIG_SECTION_SCHEDULER = "Scheduler"
+    constants_mod.CONFIG_SECTION_ACTOR = "Actor"
+    constants_mod.CONFIG_SECTION_LOGGING = "Logging"
+    constants_mod.CONFIG_SECTION_TELEGRAM = "Telegram"
+    constants_mod.CONFIG_OPTION_GITHUB_TOKEN = "github_token"
+    constants_mod.CONFIG_OPTION_SYSTEM_UPDATE_STRATEGY = "system_update_strategy"
+    constants_mod.CONFIG_OPTION_SYSTEM_UPDATE_HELPER_IMAGE = "system_update_helper_image"
+    constants_mod.CONFIG_OPTION_TELEGRAM_BOT_TOKEN = "telegram_bot_token"
+    constants_mod.CONFIG_OPTION_TELEGRAM_CHANNEL_ID = "telegram_channel_id"
+    constants_mod.CONFIG_OPTION_TELEGRAM_MENU_TASKS = "tg_menu_tasks"
+    constants_mod.CONFIG_OPTION_TELEGRAM_NOTIFY_TYPES = "telegram_notify_types"
+    constants_mod.DEFAULT_TELEGRAM_MENU_TASKS = []
+    constants_mod.DEFAULT_TELEGRAM_NOTIFY_TYPES = []
+    constants_mod.CONFIG_OPTION_EMBY_SERVER_URL = "emby_server_url"
+    constants_mod.CONFIG_OPTION_EMBY_PUBLIC_URL = "emby_public_url"
+    constants_mod.CONFIG_OPTION_EMBY_API_KEY = "emby_api_key"
+    constants_mod.CONFIG_OPTION_EMBY_USER_ID = "emby_user_id"
+    constants_mod.CONFIG_OPTION_EMBY_API_TIMEOUT = "emby_api_timeout"
+    constants_mod.CONFIG_OPTION_EMBY_LIBRARIES_TO_PROCESS = "libraries_to_process"
+    constants_mod.CONFIG_OPTION_EMBY_ADMIN_USER = "emby_admin_user"
+    constants_mod.CONFIG_OPTION_EMBY_ADMIN_PASS = "emby_admin_pass"
+    constants_mod.CONFIG_OPTION_PROXY_ENABLED = "proxy_enabled"
+    constants_mod.CONFIG_OPTION_PROXY_PORT = "proxy_port"
+    constants_mod.CONFIG_OPTION_PROXY_MERGE_NATIVE = "proxy_merge_native_libraries"
+    constants_mod.CONFIG_OPTION_PROXY_NATIVE_VIEW_SELECTION = "proxy_native_view_selection"
+    constants_mod.CONFIG_OPTION_PROXY_NATIVE_VIEW_ORDER = "proxy_native_view_order"
+    constants_mod.CONFIG_OPTION_PROXY_SHOW_MISSING_PLACEHOLDERS = "proxy_show_missing_placeholders"
+    constants_mod.CONFIG_OPTION_PROXY_302_REDIRECT_URL = "proxy_302_redirect_url"
+    constants_mod.CONFIG_OPTION_TMDB_API_KEY = "tmdb_api_key"
+    constants_mod.CONFIG_OPTION_TMDB_API_BASE_URL = "tmdb_api_base_url"
+    constants_mod.CONFIG_OPTION_TMDB_INCLUDE_ADULT = "tmdb_include_adult"
+    constants_mod.CONFIG_OPTION_TMDB_IMAGE_LANGUAGE_PREFERENCE = "tmdb_image_language_preference"
+    constants_mod.CONFIG_OPTION_DOUBAN_DEFAULT_COOLDOWN = "api_douban_default_cooldown_seconds"
+    constants_mod.CONFIG_OPTION_DOUBAN_COOKIE = "douban_cookie"
+    constants_mod.CONFIG_OPTION_DOUBAN_ENABLE_ONLINE_API = "douban_enable_online_api"
+    constants_mod.CONFIG_OPTION_MONITOR_ENABLED = "monitor_enabled"
+    constants_mod.CONFIG_OPTION_MONITOR_PATHS = "monitor_paths"
+    constants_mod.CONFIG_OPTION_MONITOR_EXTENSIONS = "monitor_extensions"
+    constants_mod.DEFAULT_MONITOR_EXTENSIONS = []
+    constants_mod.CONFIG_OPTION_MONITOR_SCAN_LOOKBACK_DAYS = "monitor_scan_lookback_days"
+    constants_mod.DEFAULT_MONITOR_SCAN_LOOKBACK_DAYS = 1
+    constants_mod.CONFIG_OPTION_MONITOR_EXCLUDE_DIRS = "monitor_exclude_dirs"
+    constants_mod.DEFAULT_MONITOR_EXCLUDE_DIRS = []
+    constants_mod.CONFIG_OPTION_MONITOR_EXCLUDE_REFRESH_DELAY = "monitor_exclude_refresh_delay"
+    constants_mod.DEFAULT_MONITOR_EXCLUDE_REFRESH_DELAY = 0
+    constants_mod.CONFIG_OPTION_MONITOR_SHA1_PC_SEARCH = "monitor_sha1_pc_search"
+    constants_mod.CONFIG_OPTION_115_SAVE_PATH_CID = "p115_save_path_cid"
+    constants_mod.CONFIG_OPTION_115_SAVE_PATH_NAME = "p115_save_path_name"
+    constants_mod.CONFIG_OPTION_115_UNRECOGNIZED_CID = "p115_unrecognized_cid"
+    constants_mod.CONFIG_OPTION_115_UNRECOGNIZED_NAME = "p115_unrecognized_name"
+    constants_mod.CONFIG_OPTION_115_MEDIA_ROOT_NAME = "p115_media_root_name"
+    constants_mod.CONFIG_OPTION_115_INTERVAL = "p115_request_interval"
+    constants_mod.CONFIG_OPTION_115_MAX_WORKERS = "p115_max_workers"
+    constants_mod.CONFIG_OPTION_115_API_PRIORITY = "p115_api_priority"
+    constants_mod.CONFIG_OPTION_115_ENABLE_ORGANIZE = "p115_enable_organize"
+    constants_mod.CONFIG_OPTION_115_MP_CLASSIFY = "p115_mp_classify"
+    constants_mod.CONFIG_OPTION_115_MIN_VIDEO_SIZE = "p115_min_video_size"
+    constants_mod.CONFIG_OPTION_115_EXTENSIONS = "p115_extensions"
+    constants_mod.CONFIG_OPTION_115_MEDIA_ROOT_CID = "p115_media_root_cid"
+    constants_mod.CONFIG_OPTION_LOCAL_STRM_ROOT = "local_strm_root"
+    constants_mod.CONFIG_OPTION_ETK_SERVER_URL = "etk_server_url"
+    constants_mod.CONFIG_OPTION_115_ENABLE_SYNC_DELETE = "p115_enable_sync_delete"
+    constants_mod.CONFIG_OPTION_115_GENERATE_MEDIAINFO = "p115_generate_mediainfo"
+    constants_mod.CONFIG_OPTION_115_DOWNLOAD_SUBS = "p115_download_subs"
+    constants_mod.CONFIG_OPTION_115_LOCAL_CLEANUP = "p115_local_cleanup"
+    constants_mod.CONFIG_OPTION_115_MEDIAINFO_CENTER = "p115_mediainfo_center"
+    constants_mod.CONFIG_OPTION_115_APP_ID = "p115_app_id"
+    constants_mod.CONFIG_OPTION_115_LIFE_MONITOR_ENABLED = "p115_life_monitor_enabled"
+    constants_mod.CONFIG_OPTION_115_LIFE_MONITOR_INTERVAL = "p115_life_monitor_interval"
+    constants_mod.CONFIG_OPTION_MIN_SCORE_FOR_REVIEW = "min_score_for_review"
+    constants_mod.DEFAULT_MIN_SCORE_FOR_REVIEW = 6.0
+    constants_mod.CONFIG_OPTION_MAX_ACTORS_TO_PROCESS = "max_actors_to_process"
+    constants_mod.DEFAULT_MAX_ACTORS_TO_PROCESS = 50
+    constants_mod.CONFIG_OPTION_MAX_EPISODE_ACTORS_TO_PROCESS = "max_episode_actors_to_process"
+    constants_mod.DEFAULT_MAX_EPISODE_ACTORS_TO_PROCESS = 0
+    constants_mod.CONFIG_OPTION_EXTRACT_THUMB = "extract_thumb"
+    constants_mod.CONFIG_OPTION_REMOVE_ACTORS_WITHOUT_AVATARS = "remove_actors_without_avatars"
+    constants_mod.CONFIG_OPTION_KEYWORD_TO_TAGS = "keyword_to_tags"
+    constants_mod.CONFIG_OPTION_STUDIO_TO_CHINESE = "studio_to_chinese"
+    constants_mod.CONFIG_OPTION_GENERATE_COLLECTION_NFO = "generate_collection_nfo"
+    constants_mod.CONFIG_OPTION_NETWORK_PROXY_ENABLED = "network_proxy_enabled"
+    constants_mod.CONFIG_OPTION_NETWORK_HTTP_PROXY = "network_http_proxy_url"
+    constants_mod.CONFIG_OPTION_AI_PROVIDER = "ai_provider"
+    constants_mod.CONFIG_OPTION_AI_API_KEY = "ai_api_key"
+    constants_mod.CONFIG_OPTION_AI_MODEL_NAME = "ai_model_name"
+    constants_mod.CONFIG_OPTION_AI_BASE_URL = "ai_base_url"
+    constants_mod.CONFIG_OPTION_AI_VECTOR = "ai_vector"
+    constants_mod.CONFIG_OPTION_AI_TRANSLATION_MODE = "ai_translation_mode"
+    constants_mod.CONFIG_OPTION_AI_TRANSLATE_ACTOR_ROLE = "ai_translate_actor_role"
+    constants_mod.CONFIG_OPTION_AI_TRANSLATE_TITLE = "ai_translate_title"
+    constants_mod.CONFIG_OPTION_AI_TRANSLATE_OVERVIEW = "ai_translate_overview"
+    constants_mod.CONFIG_OPTION_AI_TRANSLATE_EPISODE_OVERVIEW = "ai_translate_episode_overview"
+    constants_mod.CONFIG_OPTION_AI_RECOGNITION = "ai_recognition"
+    constants_mod.CONFIG_OPTION_AI_JOKE_FALLBACK = "ai_joke_fallback"
+    constants_mod.CONFIG_OPTION_TASK_CHAIN_ENABLED = "task_chain_enabled"
+    constants_mod.CONFIG_OPTION_TASK_CHAIN_CRON = "task_chain_cron"
+    constants_mod.CONFIG_OPTION_TASK_CHAIN_SEQUENCE = "task_chain_sequence"
+    constants_mod.CONFIG_OPTION_TASK_CHAIN_MAX_RUNTIME_MINUTES = "task_chain_max_runtime_minutes"
+    constants_mod.CONFIG_OPTION_TASK_CHAIN_LOW_FREQ_ENABLED = "task_chain_low_freq_enabled"
+    constants_mod.CONFIG_OPTION_TASK_CHAIN_LOW_FREQ_CRON = "task_chain_low_freq_cron"
+    constants_mod.CONFIG_OPTION_TASK_CHAIN_LOW_FREQ_SEQUENCE = "task_chain_low_freq_sequence"
+    constants_mod.CONFIG_OPTION_TASK_CHAIN_LOW_FREQ_MAX_RUNTIME_MINUTES = "task_chain_low_freq_max_runtime_minutes"
+    constants_mod.CONFIG_OPTION_ACTOR_ROLE_ADD_PREFIX = "actor_role_add_prefix"
+    constants_mod.CONFIG_OPTION_ACTOR_MAIN_ROLE_ONLY = "actor_main_role_only"
+    constants_mod.CONFIG_OPTION_LOG_ROTATION_SIZE_MB = "log_rotation_size_mb"
+    constants_mod.CONFIG_OPTION_LOG_ROTATION_BACKUPS = "log_rotation_backup_count"
+    constants_mod.DEFAULT_LOG_ROTATION_SIZE_MB = 5
+    constants_mod.DEFAULT_LOG_ROTATION_BACKUPS = 10
+    constants_mod.ENV_VAR_DB_HOST = "DB_HOST"
+    constants_mod.ENV_VAR_DB_PORT = "DB_PORT"
+    constants_mod.ENV_VAR_DB_USER = "DB_USER"
+    constants_mod.ENV_VAR_DB_PASSWORD = "DB_PASSWORD"
+    constants_mod.ENV_VAR_DB_NAME = "DB_NAME"
+    constants_mod.ENV_VAR_TMDB_API_BASE_URL = "TMDB_API_BASE_URL"
+    sys.modules["constants"] = constants_mod
+
+    settings_db_mod = sys.modules.get("database.settings_db") or types.ModuleType("database.settings_db")
+    settings_db_mod.get_setting = lambda key: {}
+    settings_db_mod.save_setting = lambda key, value: None
+    settings_db_mod.delete_setting = lambda key: True
+
+    user_db_mod = sys.modules.get("database.user_db") or types.ModuleType("database.user_db")
+    user_db_mod.get_admin_telegram_chat_ids = lambda: ["10001"]
+
+    database_pkg = sys.modules.get("database") or types.ModuleType("database")
+    database_pkg.settings_db = settings_db_mod
+    database_pkg.user_db = user_db_mod
+    sys.modules["database"] = database_pkg
+    sys.modules["database.settings_db"] = settings_db_mod
+    sys.modules["database.user_db"] = user_db_mod
+
+    handler_telegram_mod = sys.modules.get("handler.telegram") or types.ModuleType("handler.telegram")
+    handler_telegram_mod.send_telegram_message = lambda *args, **kwargs: None
+    handler_telegram_mod.escape_markdown = lambda text: text
+    sys.modules["handler.telegram"] = handler_telegram_mod
+
+    tasks_system_update = sys.modules.get("tasks.system_update") or types.ModuleType("tasks.system_update")
+    tasks_system_update.consume_post_update_status = lambda: None
+    sys.modules["tasks.system_update"] = tasks_system_update
+
+
+_install_stubs()
+sys.modules.pop("config_manager", None)
+config_manager = importlib.import_module("config_manager")
+
+
+class PostUpdateNotifyTests(unittest.TestCase):
+    def test_notify_pending_system_update_result_sends_admin_message(self):
+        payload = {
+            "ok": True,
+            "current_version": "10.2.5",
+            "target_version": "v10.2.6",
+            "message": "容器健康检查通过。",
+        }
+        with mock.patch("tasks.system_update.consume_post_update_status", return_value=payload):
+            with mock.patch("handler.telegram.send_telegram_message") as send_mock:
+                config_manager._notify_pending_system_update_result()
+
+        send_mock.assert_called_once()
+        message = send_mock.call_args.args[1]
+        self.assertIn("系统自动更新", message)
+        self.assertIn("10.2.5", message)
+        self.assertIn("v10.2.6", message)
+        self.assertIn("容器健康检查通过。", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telegram_system_update_notification.py
+++ b/tests/test_telegram_system_update_notification.py
@@ -8,6 +8,7 @@ from unittest import mock
 def _install_test_stubs():
     config_manager_mod = sys.modules.get("config_manager") or types.ModuleType("config_manager")
     config_manager_mod.APP_CONFIG = {}
+    config_manager_mod.PERSISTENT_DATA_PATH = "/tmp"
     config_manager_mod.get_proxies_for_requests = lambda: None
     sys.modules["config_manager"] = config_manager_mod
 
@@ -21,6 +22,8 @@ def _install_test_stubs():
     constants_mod.CONFIG_OPTION_EMBY_API_KEY = "emby_api_key"
     constants_mod.CONFIG_OPTION_EMBY_USER_ID = "emby_user_id"
     constants_mod.CONFIG_OPTION_GITHUB_TOKEN = "github_token"
+    constants_mod.CONFIG_OPTION_SYSTEM_UPDATE_STRATEGY = "system_update_strategy"
+    constants_mod.CONFIG_OPTION_SYSTEM_UPDATE_HELPER_IMAGE = "system_update_helper_image"
     constants_mod.GITHUB_REPO_OWNER = "hbq0405"
     constants_mod.GITHUB_REPO_NAME = "emby-toolkit"
     sys.modules["constants"] = constants_mod
@@ -85,6 +88,11 @@ system_update = importlib.import_module("tasks.system_update")
 
 
 class TelegramSystemUpdateNotificationTests(unittest.TestCase):
+    def test_resolve_update_strategy_defaults_to_docker_helper(self):
+        resolved = system_update.resolve_update_strategy({})
+        self.assertEqual(resolved["strategy"], "docker_helper")
+        self.assertEqual(resolved["helper_image"], "hbq0405/emby-toolkit:latest")
+
     def test_resolve_update_target_falls_back_to_env(self):
         with mock.patch.dict("os.environ", {"CONTAINER_NAME": "etk-prod", "DOCKER_IMAGE_NAME": "hbq0405/emby-toolkit:v10.2.4"}, clear=False):
             resolved = system_update.resolve_update_target({}, docker_client=object())
@@ -103,27 +111,31 @@ class TelegramSystemUpdateNotificationTests(unittest.TestCase):
 
         with mock.patch.object(system_update, "get_system_update_version_info", return_value={"current_version": "10.2.3", "target_version": "v10.2.4"}):
             with mock.patch.object(system_update, "resolve_update_target", return_value={"container_name": "etk-prod", "docker_image_name": "hbq0405/emby-toolkit:v10.2.4"}):
-                with mock.patch.object(telegram, "send_telegram_message") as send_mock:
-                    with mock.patch("handler.telegram.threading.Thread") as thread_mock:
-                        thread_mock.return_value.start.side_effect = lambda: thread_mock.call_args.kwargs["target"]()
+                with mock.patch.object(system_update, "resolve_update_strategy", return_value={"strategy": "docker_helper", "helper_image": "hbq0405/emby-toolkit:latest"}):
+                    with mock.patch.object(telegram, "send_telegram_message") as send_mock:
+                        with mock.patch("handler.telegram.threading.Thread") as thread_mock:
+                            thread_mock.return_value.start.side_effect = lambda: thread_mock.call_args.kwargs["target"]()
 
-                        registry = {
-                            "system-auto-update": (fake_update_task, "系统自动更新", "media")
-                        }
-                        with mock.patch("tasks.core.get_task_registry", return_value=registry):
-                            telegram._execute_task_from_tg("10001", "system-auto-update")
+                            registry = {
+                                "system-auto-update": (fake_update_task, "系统自动更新", "media")
+                            }
+                            with mock.patch("tasks.core.get_task_registry", return_value=registry):
+                                telegram._execute_task_from_tg("10001", "system-auto-update")
 
         self.assertEqual(send_mock.call_count, 2)
         start_message = send_mock.call_args_list[0].args[1]
         finish_message = send_mock.call_args_list[1].args[1]
-        self.assertIn("当前版本: \\`10\\.2\\.3\\`", start_message)
-        self.assertIn("目标版本: \\`v10\\.2\\.4\\`", start_message)
-        self.assertIn("目标容器: \\`etk\\-prod\\`", start_message)
-        self.assertIn("目标镜像: \\`hbq0405/emby\\-toolkit:v10\\.2\\.4\\`", start_message)
+        normalized_start = start_message.replace("\\", "")
+        normalized_finish = finish_message.replace("\\", "")
+        self.assertIn("当前版本: `10.2.3`", normalized_start)
+        self.assertIn("目标版本: `v10.2.4`", normalized_start)
+        self.assertIn("目标容器: `etk-prod`", normalized_start)
+        self.assertIn("目标镜像: `hbq0405/emby-toolkit:v10.2.4`", normalized_start)
+        self.assertIn("更新策略: `docker_helper`", normalized_start)
         self.assertIn("❌ 任务执行失败", finish_message)
-        self.assertIn("当前版本: \\`10\\.2\\.3\\`", finish_message)
-        self.assertIn("目标版本: \\`v10\\.2\\.4\\`", finish_message)
-        self.assertIn("错误信息: 无法连接 Docker 守护进程", finish_message)
+        self.assertIn("当前版本: `10.2.3`", normalized_finish)
+        self.assertIn("目标版本: `v10.2.4`", normalized_finish)
+        self.assertIn("错误信息: 无法连接 Docker 守护进程", normalized_finish)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 变更说明
- 将系统自动更新默认策略从 watchtower 切换为 docker_helper
- 通过一次性 helper 容器复用原容器配置并重建目标容器，失败时尝试回滚
- 保留 watchtower 作为兼容回退策略，并在 TG 开始通知中显示当前更新策略
- 新容器启动后读取更新结果文件，向管理员补发最终 TG 通知

## 背景
- 现有实现把更新交给 watchtower，但在部分 Docker 运行环境中会出现镜像已拉取、容器未重建的情况
- 对 Docker 容器来说，重启不是更新；真正更新需要外部执行者基于新镜像重建容器
- 这次改动把默认执行路径调整为通用的 docker helper 交接模式，避免继续依赖 watchtower 的自更新链路

## 验证
- `python -m unittest tests.test_telegram_system_update_notification tests.test_system_update_post_notify`
- `python -m py_compile tasks/system_update.py config_manager.py handler/telegram.py tests/test_telegram_system_update_notification.py tests/test_system_update_post_notify.py`
- `git diff --check`

## 兼容性说明
- 默认策略为 `docker_helper`
- 如已有部署明确依赖 watchtower，可通过 `system_update_strategy=watchtower` 切回旧策略
- helper 方案已覆盖常见 Docker 配置复刻，但极少见的高级 HostConfig 组合仍建议继续补充真实环境验证
