### PR TITLE
修复媒体任务繁忙时 Webhook 队列固定重试仍会丢单的问题

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -47,8 +47,10 @@ WEBHOOK_BATCH_QUEUE = collections.deque()
 WEBHOOK_BATCH_LOCK = threading.Lock()
 WEBHOOK_BATCH_DEBOUNCE_TIME = 30
 WEBHOOK_BATCH_DEBOUNCER = None
-WEBHOOK_TASK_RETRY_DELAY = 8
-WEBHOOK_TASK_MAX_RETRIES = 3
+WEBHOOK_REQUEUE_DELAY = 5
+WEBHOOK_PENDING_TASKS = collections.deque()
+WEBHOOK_PENDING_TASKS_LOCK = threading.Lock()
+WEBHOOK_PENDING_TASKS_DRAINER = None
 
 UPDATE_DEBOUNCE_TIMERS = {}
 UPDATE_DEBOUNCE_LOCK = threading.Lock()
@@ -69,12 +71,18 @@ MP_BATCH_LOCK = threading.Lock()
 def _submit_webhook_media_task(
     task_name,
     *,
-    retry_count=0,
     task_function=None,
     processor_type='media',
+    from_pending_queue=False,
     **kwargs,
 ):
     task_function = task_function or _handle_full_processing_flow
+    task_payload = {
+        "task_name": task_name,
+        "task_function": task_function,
+        "processor_type": processor_type,
+        "kwargs": dict(kwargs),
+    }
     submitted = task_manager.submit_task(
         task_function,
         task_name=task_name,
@@ -82,29 +90,80 @@ def _submit_webhook_media_task(
         **kwargs,
     )
     if submitted:
-        if retry_count > 0:
-            logger.info(f"  ➜ [Webhook重试] 任务 '{task_name}' 第 {retry_count} 次延迟重试后提交成功。")
+        if from_pending_queue:
+            logger.info(f"  ➜ [Webhook队列] 任务 '{task_name}' 已从待提交队列成功分派。")
         return True
 
-    if retry_count >= WEBHOOK_TASK_MAX_RETRIES:
-        logger.warning(f"  ➜ [Webhook重试] 任务 '{task_name}' 多次重试后仍提交失败，放弃。")
+    if from_pending_queue:
+        logger.debug(f"  ➜ [Webhook队列] 任务 '{task_name}' 分派时媒体任务仍繁忙，稍后继续尝试。")
         return False
 
-    next_retry = retry_count + 1
-    logger.info(
-        f"  ➜ [Webhook重试] 任务 '{task_name}' 因媒体任务繁忙延迟 {WEBHOOK_TASK_RETRY_DELAY} 秒后重试 "
-        f"(第 {next_retry}/{WEBHOOK_TASK_MAX_RETRIES} 次)。"
-    )
-    spawn_later(
-        WEBHOOK_TASK_RETRY_DELAY,
-        _submit_webhook_media_task,
-        task_name,
-        retry_count=next_retry,
-        task_function=task_function,
-        processor_type=processor_type,
-        **kwargs,
-    )
+    logger.info(f"  ➜ [Webhook队列] 任务 '{task_name}' 因媒体任务繁忙，已加入待提交队列。")
+    _enqueue_pending_webhook_task(task_payload)
     return False
+
+
+def _is_same_pending_webhook_task(existing_task, new_task):
+    return (
+        existing_task.get("task_name") == new_task.get("task_name")
+        and existing_task.get("processor_type") == new_task.get("processor_type")
+        and existing_task.get("task_function") == new_task.get("task_function")
+        and existing_task.get("kwargs") == new_task.get("kwargs")
+    )
+
+
+def _schedule_pending_webhook_drain(delay=WEBHOOK_REQUEUE_DELAY):
+    global WEBHOOK_PENDING_TASKS_DRAINER
+    with WEBHOOK_PENDING_TASKS_LOCK:
+        if WEBHOOK_PENDING_TASKS_DRAINER is not None:
+            return
+        WEBHOOK_PENDING_TASKS_DRAINER = spawn_later(delay, _drain_pending_webhook_tasks)
+
+
+def _enqueue_pending_webhook_task(task_payload):
+    with WEBHOOK_PENDING_TASKS_LOCK:
+        for pending_task in WEBHOOK_PENDING_TASKS:
+            if _is_same_pending_webhook_task(pending_task, task_payload):
+                logger.debug(f"  ➜ [Webhook队列] 任务 '{task_payload['task_name']}' 已在待提交队列中，跳过重复入队。")
+                break
+        else:
+            WEBHOOK_PENDING_TASKS.append(task_payload)
+            logger.info(
+                f"  ➜ [Webhook队列] 当前待提交任务数: {len(WEBHOOK_PENDING_TASKS)} "
+                f"(最新: {task_payload['task_name']})"
+            )
+
+    _schedule_pending_webhook_drain()
+
+
+def _drain_pending_webhook_tasks():
+    global WEBHOOK_PENDING_TASKS_DRAINER
+    try:
+        while True:
+            with WEBHOOK_PENDING_TASKS_LOCK:
+                if not WEBHOOK_PENDING_TASKS:
+                    return
+                task_payload = WEBHOOK_PENDING_TASKS[0]
+
+            submitted = _submit_webhook_media_task(
+                task_payload["task_name"],
+                task_function=task_payload["task_function"],
+                processor_type=task_payload["processor_type"],
+                from_pending_queue=True,
+                **task_payload["kwargs"],
+            )
+            if not submitted:
+                return
+
+            with WEBHOOK_PENDING_TASKS_LOCK:
+                if WEBHOOK_PENDING_TASKS and _is_same_pending_webhook_task(WEBHOOK_PENDING_TASKS[0], task_payload):
+                    WEBHOOK_PENDING_TASKS.popleft()
+    finally:
+        with WEBHOOK_PENDING_TASKS_LOCK:
+            WEBHOOK_PENDING_TASKS_DRAINER = None
+            has_pending_tasks = bool(WEBHOOK_PENDING_TASKS)
+        if has_pending_tasks:
+            _schedule_pending_webhook_drain()
 
 
 def _mp_rel_dir_from_115_path(path):
@@ -774,7 +833,7 @@ def _process_batch_webhook_events():
             is_new_item=not is_already_processed
         )
 
-    logger.info("  ➜ 所有 Webhook 批量任务已成功分派。")
+    logger.info("  ➜ 所有 Webhook 批量任务已完成分派或进入待提交队列。")
 
 def _trigger_metadata_update_task(item_id, item_name):
     """触发元数据同步任务"""

--- a/tests/test_webhook_task_retry.py
+++ b/tests/test_webhook_task_retry.py
@@ -174,7 +174,11 @@ webhook = importlib.import_module("routes.webhook")
 
 
 class WebhookTaskRetryTests(unittest.TestCase):
-    def test_busy_worker_schedules_retry(self):
+    def setUp(self):
+        webhook.WEBHOOK_PENDING_TASKS.clear()
+        webhook.WEBHOOK_PENDING_TASKS_DRAINER = None
+
+    def test_busy_worker_enqueues_pending_task(self):
         with mock.patch.object(webhook.task_manager, "submit_task", return_value=False) as submit_mock:
             with mock.patch.object(webhook, "spawn_later") as spawn_later_mock:
                 result = webhook._submit_webhook_media_task(
@@ -185,35 +189,62 @@ class WebhookTaskRetryTests(unittest.TestCase):
         self.assertFalse(result)
         submit_mock.assert_called_once()
         spawn_later_mock.assert_called_once()
-        self.assertEqual(spawn_later_mock.call_args.args[0], webhook.WEBHOOK_TASK_RETRY_DELAY)
-        self.assertIs(spawn_later_mock.call_args.args[1], webhook._submit_webhook_media_task)
-        self.assertEqual(spawn_later_mock.call_args.args[2], "Webhook入库: Test")
-        self.assertEqual(spawn_later_mock.call_args.kwargs["retry_count"], 1)
+        self.assertEqual(spawn_later_mock.call_args.args[0], webhook.WEBHOOK_REQUEUE_DELAY)
+        self.assertIs(spawn_later_mock.call_args.args[1], webhook._drain_pending_webhook_tasks)
+        self.assertEqual(len(webhook.WEBHOOK_PENDING_TASKS), 1)
+        self.assertEqual(webhook.WEBHOOK_PENDING_TASKS[0]["task_name"], "Webhook入库: Test")
 
-    def test_retry_stops_after_max_attempts(self):
+    def test_duplicate_pending_task_is_not_enqueued_twice(self):
+        task_fn = lambda **kwargs: None
         with mock.patch.object(webhook.task_manager, "submit_task", return_value=False):
             with mock.patch.object(webhook, "spawn_later") as spawn_later_mock:
-                result = webhook._submit_webhook_media_task(
+                first = webhook._submit_webhook_media_task(
                     "Webhook入库: Test",
-                    retry_count=webhook.WEBHOOK_TASK_MAX_RETRIES,
-                    task_function=lambda **kwargs: None,
+                    task_function=task_fn,
                     item_id="123",
                 )
-        self.assertFalse(result)
-        spawn_later_mock.assert_not_called()
+                second = webhook._submit_webhook_media_task(
+                    "Webhook入库: Test",
+                    task_function=task_fn,
+                    item_id="123",
+                )
+        self.assertFalse(first)
+        self.assertFalse(second)
+        self.assertEqual(len(webhook.WEBHOOK_PENDING_TASKS), 1)
+        spawn_later_mock.assert_called_once()
 
-    def test_retry_success_logs_and_returns_true(self):
+    def test_pending_queue_submission_success_drains_head(self):
+        task_fn = lambda **kwargs: None
+        webhook.WEBHOOK_PENDING_TASKS.append(
+            {
+                "task_name": "Webhook入库: Test",
+                "task_function": task_fn,
+                "processor_type": "media",
+                "kwargs": {"item_id": "123"},
+            }
+        )
         with mock.patch.object(webhook.task_manager, "submit_task", return_value=True) as submit_mock:
             with mock.patch.object(webhook.logger, "info") as logger_mock:
-                result = webhook._submit_webhook_media_task(
-                    "Webhook入库: Test",
-                    retry_count=1,
-                    task_function=lambda **kwargs: None,
-                    item_id="123",
-                )
-        self.assertTrue(result)
+                webhook._drain_pending_webhook_tasks()
         submit_mock.assert_called_once()
         logger_mock.assert_called()
+        self.assertEqual(len(webhook.WEBHOOK_PENDING_TASKS), 0)
+
+    def test_pending_queue_failure_keeps_task_and_reschedules(self):
+        task_fn = lambda **kwargs: None
+        webhook.WEBHOOK_PENDING_TASKS.append(
+            {
+                "task_name": "Webhook入库: Test",
+                "task_function": task_fn,
+                "processor_type": "media",
+                "kwargs": {"item_id": "123"},
+            }
+        )
+        with mock.patch.object(webhook.task_manager, "submit_task", return_value=False):
+            with mock.patch.object(webhook, "spawn_later") as spawn_later_mock:
+                webhook._drain_pending_webhook_tasks()
+        self.assertEqual(len(webhook.WEBHOOK_PENDING_TASKS), 1)
+        spawn_later_mock.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

这个 PR 修复的是 Webhook 媒体任务的调度问题：当 `media` worker 正在执行长时间整理任务时，Webhook 任务即使做固定次数的延迟重试，仍然可能在固定窗口内连续撞锁，最终被放弃。

这次改动不再依赖“延迟几秒、重试几次”的固定窗口，而是把忙时未能提交的 Webhook 媒体任务放入一个待提交队列，等 `media` worker 空闲后再自动串行分派。

## 运行态证据

Unraid live 日志可以直接对上这个问题：

- `2026-06-03 20:08:03`，`Webhook入库: 青年夏洛克` 开始尝试提交
- 同一时间 `百万秘宝攻防战` 的 115 整理和后续重命名仍在持续执行
- `Webhook入库: 青年夏洛克` 在 `20:08:03 / 20:08:11 / 20:08:19 / 20:08:27` 连续撞上 `已有任务正在运行`
- 当前媒体主任务直到 `2026-06-03 20:09:18` 左右才真正结束

这说明问题不是“8 秒不够精确”，而是固定重试窗口天然可能短于实际媒体任务执行时长。

## 根因

当前逻辑中：

- `task_manager.submit_task(...)` 对 `media` 任务使用非阻塞全局锁
- 如果已有媒体任务在运行，会立即返回 `False`
- Webhook 侧之前采用的是固定延迟、有限次数的重试
- 一旦当前媒体任务执行时间超过重试窗口，Webhook 任务仍然会被放弃

因此，固定重试只是缓解，不是稳定解法。

## 本次修改

### 1. 将固定重试改为 Webhook 专属待提交队列

在 `routes/webhook.py` 中新增：

- `WEBHOOK_PENDING_TASKS`
- `WEBHOOK_PENDING_TASKS_LOCK`
- `WEBHOOK_PENDING_TASKS_DRAINER`
- `_enqueue_pending_webhook_task(...)`
- `_drain_pending_webhook_tasks(...)`

行为变为：

- Webhook 媒体任务提交成功时，保持原逻辑
- 如果因 `media` worker 忙而提交失败：
  - 不再按固定次数重试
  - 直接进入待提交队列
  - 由 drain 逻辑定期检查并串行重新提交
- 当前队首任务提交成功后，再继续提交下一项

### 2. 对待提交任务做轻量去重

待提交队列会按以下信息判定重复：

- `task_name`
- `processor_type`
- `task_function`
- `kwargs`

如果同一个 Webhook 任务已经在待提交队列中，就不重复入队，避免繁忙窗口内无意义堆积。

### 3. 保持改动范围只在 Webhook 调度层

本 PR 没有修改：

- `task_manager` 的全局锁模型
- TG 整理任务调度
- MoviePilot / TMDb / p115 识别链
- 数据库结构
- 前端 UI

也就是说，这次仍然是一个小范围调度修复，只把 Webhook 从“忙时可能丢单”改为“忙时排队等待提交”。

## 为什么这样改

这个方案比继续调大 `8s`、增加重试次数更稳：

- 媒体任务实际时长波动很大，固定窗口不可预测
- 待提交队列直接对齐现有单 worker 串行模型
- 不需要重构整个任务系统
- 风险和改动面都更可控

## 已知限制

- Webhook 待提交队列是进程内内存队列
- 如果容器在任务正式提交前重启，未提交的 Webhook 任务会丢弃
- 当前版本明确不做重启恢复机制

这是当前版本的有意范围控制，不在这次修复里继续扩展到持久化排队。

## 验证

已执行：

```bash
python -m py_compile routes/webhook.py tests/test_webhook_task_retry.py
python -m unittest tests.test_webhook_task_retry -v
git diff --check
```

结果：

- 单测通过
- 语法检查通过
- diff 卫生检查通过

## 测试覆盖

更新后的测试覆盖：

- worker 忙时任务进入待提交队列
- 相同待提交任务不会重复入队
- 待提交队列任务成功提交后会从队首移除
- 待提交队列任务提交失败时会保留并重新调度 drain

## 后续可选项

如果后续还要继续优化，可以再单独讨论：

- 是否把待提交队列持久化，支持重启恢复
- 是否把 `media` 任务整体升级为正式串行排队模型
- 是否为不同来源任务增加优先级
