### PR TITLE
修复 Docker Helper 自动更新未覆盖 entrypoint 导致执行主程序

### DIFF
--- a/tasks/system_update.py
+++ b/tasks/system_update.py
@@ -515,7 +515,8 @@ def _run_docker_helper(client, helper_image, container_name, image_name_tag, ver
     try:
         output = client.containers.run(
             image=helper_image,
-            command=["python", "/tmp/etk_update_helper.py"],
+            entrypoint=["python"],
+            command=["/tmp/etk_update_helper.py"],
             remove=True,
             detach=False,
             environment=env,

--- a/tests/test_telegram_system_update_notification.py
+++ b/tests/test_telegram_system_update_notification.py
@@ -137,6 +137,33 @@ class TelegramSystemUpdateNotificationTests(unittest.TestCase):
         self.assertIn("目标版本: `v10.2.4`", normalized_finish)
         self.assertIn("错误信息: 无法连接 Docker 守护进程", normalized_finish)
 
+    def test_run_docker_helper_overrides_entrypoint(self):
+        fake_client = mock.Mock()
+        fake_client.containers.run.return_value = b"ok"
+        fake_client.images.get.return_value = object()
+
+        with mock.patch.object(system_update, "_get_update_status_path", return_value="/tmp/system_update_result.json"):
+            with mock.patch.object(system_update, "_read_json_file", return_value={"ok": True, "message": "done"}):
+                with mock.patch("tempfile.NamedTemporaryFile") as tmp_file:
+                    tmp_cm = mock.MagicMock()
+                    tmp_cm.__enter__.return_value.name = "/tmp/helper.py"
+                    tmp_cm.__enter__.return_value.write.return_value = None
+                    tmp_cm.__exit__.return_value = False
+                    tmp_file.return_value = tmp_cm
+                    with mock.patch("os.makedirs"), mock.patch("os.remove", side_effect=FileNotFoundError()):
+                        events = list(system_update._run_docker_helper(
+                            fake_client,
+                            "hbq0405/emby-toolkit:latest",
+                            "emby-toolkit",
+                            "hbq0405/emby-toolkit:latest",
+                            {"current_version": "10.2.8", "target_version": "v10.2.9"},
+                        ))
+
+        self.assertTrue(events)
+        _, kwargs = fake_client.containers.run.call_args
+        self.assertEqual(kwargs["entrypoint"], ["python"])
+        self.assertEqual(kwargs["command"], ["/tmp/etk_update_helper.py"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 变更说明
- 修复 Docker Helper 启动时未覆盖镜像默认 `ENTRYPOINT`，导致容器错误执行 ETK 主程序的问题
- 将 helper 启动参数拆分为 `entrypoint=["python"]` 和 `command=["/tmp/etk_update_helper.py"]`
- 补充回归测试，确保后续不会再次遗漏 `entrypoint` 覆盖

## 背景
- `PR58` 将系统自动更新默认策略切换为 `docker_helper`
- 实机触发后发现 helper 容器并没有执行一次性更新脚本，而是进入了镜像默认入口并启动 ETK 主程序
- 这会导致 TG 自动更新失败，并伴随主程序启动阶段的数据库连接报错

## 问题原因
- 之前实现只传入了 `command=["python", "/tmp/etk_update_helper.py"]`
- 但没有覆盖镜像自带的 `ENTRYPOINT`
- 对于 `hbq0405/emby-toolkit:latest` 这类镜像，Docker 会先进入默认入口，因此实际执行路径错误

## 验证
- `python -m py_compile tasks/system_update.py tests/test_telegram_system_update_notification.py`
- `python -m unittest tests.test_telegram_system_update_notification`
- `git diff --check`

## 说明
- 这是对 `PR58` 已合并功能的后续修复 PR
- 范围只聚焦在 Docker Helper 启动入口问题，不调整既有更新策略设计
