### PR TITLE
修复 Docker Helper 自动更新在容器环境下的脚本挂载与状态回写问题

### DIFF
--- a/tasks/system_update.py
+++ b/tasks/system_update.py
@@ -1,9 +1,8 @@
 import json
 import logging
 import os
-import tempfile
 import time
-from pathlib import Path
+import posixpath
 
 import docker
 
@@ -298,6 +297,14 @@ def _clean_version_text(value, default=None):
     return text or default
 
 
+def _log_trace(message):
+    trace_logger = getattr(logger, 'trace', None)
+    if callable(trace_logger):
+        trace_logger(message)
+        return
+    logger.debug(message)
+
+
 def _read_json_file(path):
     try:
         with open(path, 'r', encoding='utf-8') as fh:
@@ -338,6 +345,73 @@ def consume_post_update_status():
     except Exception as e:
         logger.warning(f"删除更新状态文件失败: {status_path}, err={e}")
     return payload
+
+
+def _normalize_container_path(path_value):
+    path_text = _clean_version_text(path_value)
+    if not path_text:
+        return None
+    normalized = posixpath.normpath(path_text)
+    if not normalized.startswith('/'):
+        normalized = f"/{normalized.lstrip('/')}"
+    return normalized
+
+
+def _is_container_subpath(path_value, parent_path):
+    if path_value == parent_path:
+        return True
+    return path_value.startswith(parent_path.rstrip('/') + '/')
+
+
+def _resolve_helper_status_volume(container, status_path):
+    normalized_status_path = _normalize_container_path(status_path)
+    if not normalized_status_path:
+        return None, "系统更新状态文件路径无效。"
+
+    container_attrs = getattr(container, 'attrs', {}) or {}
+    mounts = container_attrs.get('Mounts') or []
+    matched_mount = None
+    matched_destination = None
+
+    for mount in mounts:
+        destination = _normalize_container_path(mount.get('Destination') or mount.get('Target'))
+        if not destination or not _is_container_subpath(normalized_status_path, destination):
+            continue
+        if matched_destination and len(destination) <= len(matched_destination):
+            continue
+        matched_mount = mount
+        matched_destination = destination
+
+    if not matched_mount or not matched_destination:
+        return None, f"无法为状态文件 '{normalized_status_path}' 定位目标容器的持久化挂载。"
+
+    mount_type = _clean_version_text(matched_mount.get('Type')).lower()
+    if mount_type == 'tmpfs':
+        return None, f"状态文件所在挂载 '{matched_destination}' 是 tmpfs，容器重启后无法保留更新结果。"
+
+    source = None
+    if mount_type == 'volume':
+        source = _clean_version_text(matched_mount.get('Name') or matched_mount.get('Source'))
+    else:
+        source = _clean_version_text(matched_mount.get('Source') or matched_mount.get('Name'))
+
+    if not source:
+        return None, f"状态文件所在挂载 '{matched_destination}' 缺少可复用的挂载源。"
+
+    mode = _clean_version_text(matched_mount.get('Mode'))
+    if not mode:
+        mode = 'rw' if matched_mount.get('RW', True) else 'ro'
+    mode_tokens = [token.strip() for token in mode.split(',') if token.strip()]
+    access_mode = 'rw'
+    if 'ro' in mode_tokens or matched_mount.get('RW') is False:
+        access_mode = 'ro'
+
+    if access_mode != 'rw':
+        return None, f"状态文件所在挂载 '{matched_destination}' 为只读，无法写入更新结果。"
+
+    return {
+        source: {'bind': matched_destination, 'mode': 'rw'},
+    }, None
 
 
 def _resolve_self_container_target(client):
@@ -495,16 +569,32 @@ def _run_docker_helper(client, helper_image, container_name, image_name_tag, ver
     for event in _ensure_helper_image(client, helper_image, version_info):
         yield event
 
-    env = _build_helper_environment(status_path, container_name, image_name_tag, version_info)
-    with tempfile.NamedTemporaryFile('w', encoding='utf-8', suffix='.py', delete=False) as tmp_script:
-        tmp_script.write(DOCKER_HELPER_SCRIPT)
-        helper_script_path = tmp_script.name
+    try:
+        target_container = client.containers.get(container_name)
+    except Exception as e:
+        yield {
+            "status": f"启动 Docker Helper 失败: 无法定位目标容器 '{container_name}': {e}",
+            "event": "ERROR",
+            "current_version": version_info.get('current_version'),
+            "target_version": version_info.get('target_version'),
+        }
+        return
 
+    helper_status_volume, volume_error = _resolve_helper_status_volume(target_container, status_path)
+    if volume_error:
+        yield {
+            "status": f"启动 Docker Helper 失败: {volume_error}",
+            "event": "ERROR",
+            "current_version": version_info.get('current_version'),
+            "target_version": version_info.get('target_version'),
+        }
+        return
+
+    env = _build_helper_environment(status_path, container_name, image_name_tag, version_info)
     volumes = {
         '/var/run/docker.sock': {'bind': '/var/run/docker.sock', 'mode': 'rw'},
-        persistent_root: {'bind': persistent_root, 'mode': 'rw'},
-        helper_script_path: {'bind': '/tmp/etk_update_helper.py', 'mode': 'ro'},
     }
+    volumes.update(helper_status_volume)
 
     yield {
         "status": f"正在启动 Docker Helper 更新容器 '{container_name}'...",
@@ -515,8 +605,7 @@ def _run_docker_helper(client, helper_image, container_name, image_name_tag, ver
     try:
         output = client.containers.run(
             image=helper_image,
-            entrypoint=["python"],
-            command=["/tmp/etk_update_helper.py"],
+            entrypoint=["python", "-c", DOCKER_HELPER_SCRIPT],
             remove=True,
             detach=False,
             environment=env,
@@ -531,11 +620,6 @@ def _run_docker_helper(client, helper_image, container_name, image_name_tag, ver
             "target_version": version_info.get('target_version'),
         }
         return
-    finally:
-        try:
-            os.remove(helper_script_path)
-        except FileNotFoundError:
-            pass
 
     status_payload = _read_json_file(status_path)
     if not status_payload:
@@ -727,7 +811,7 @@ def task_check_and_update_container(processor):
     image_name_tag = update_target['docker_image_name']
     strategy_name = strategy_info['strategy']
     helper_image = strategy_info['helper_image']
-    logger.trace(f"--- 开始执行系统更新检查 (容器: {container_name}, 策略: {strategy_name}) ---")
+    _log_trace(f"--- 开始执行系统更新检查 (容器: {container_name}, 策略: {strategy_name}) ---")
     task_manager.update_status_from_thread(0, "准备检查更新...")
     result = {
         "ok": False,

--- a/tests/test_telegram_system_update_notification.py
+++ b/tests/test_telegram_system_update_notification.py
@@ -88,6 +88,33 @@ system_update = importlib.import_module("tasks.system_update")
 
 
 class TelegramSystemUpdateNotificationTests(unittest.TestCase):
+    def test_task_check_and_update_container_falls_back_when_logger_has_no_trace(self):
+        fake_processor = types.SimpleNamespace(config={})
+        fake_logger = mock.Mock(spec=["debug", "info", "error", "warning"])
+
+        with mock.patch.object(system_update, "resolve_update_target", return_value={
+            "container_name": "etk-prod",
+            "docker_image_name": "hbq0405/emby-toolkit:latest",
+        }):
+            with mock.patch.object(system_update, "resolve_update_strategy", return_value={
+                "strategy": "docker_helper",
+                "helper_image": "hbq0405/emby-toolkit:latest",
+            }):
+                with mock.patch.object(system_update, "get_system_update_version_info", return_value={
+                    "current_version": "10.3.0",
+                    "target_version": "v10.3.1",
+                }):
+                    with mock.patch.object(system_update, "_update_process_generator", return_value=iter([
+                        {"status": "当前容器已运行最新镜像，无需更新。", "event": "NO_UPDATE", "current_version": "10.3.0", "target_version": "v10.3.1"}
+                    ])):
+                        with mock.patch.object(system_update, "logger", fake_logger):
+                            result = system_update.task_check_and_update_container(fake_processor)
+
+        self.assertTrue(result["ok"])
+        self.assertFalse(result["updated"])
+        self.assertEqual(result["status"], "up_to_date")
+        fake_logger.debug.assert_called()
+
     def test_resolve_update_strategy_defaults_to_docker_helper(self):
         resolved = system_update.resolve_update_strategy({})
         self.assertEqual(resolved["strategy"], "docker_helper")
@@ -137,32 +164,109 @@ class TelegramSystemUpdateNotificationTests(unittest.TestCase):
         self.assertIn("目标版本: `v10.2.4`", normalized_finish)
         self.assertIn("错误信息: 无法连接 Docker 守护进程", normalized_finish)
 
-    def test_run_docker_helper_overrides_entrypoint(self):
+    def test_resolve_helper_status_volume_uses_target_mount(self):
+        fake_container = mock.Mock()
+        fake_container.attrs = {
+            "Mounts": [
+                {
+                    "Type": "bind",
+                    "Source": "/srv/etk-config",
+                    "Destination": "/config",
+                    "Mode": "rw",
+                    "RW": True,
+                }
+            ]
+        }
+
+        volumes, error = system_update._resolve_helper_status_volume(
+            fake_container,
+            "/config/system_update_result.json",
+        )
+
+        self.assertIsNone(error)
+        self.assertEqual(volumes, {
+            "/srv/etk-config": {"bind": "/config", "mode": "rw"}
+        })
+
+    def test_resolve_helper_status_volume_rejects_unmounted_status_path(self):
+        fake_container = mock.Mock()
+        fake_container.attrs = {
+            "Mounts": [
+                {
+                    "Type": "bind",
+                    "Source": "/srv/other",
+                    "Destination": "/data",
+                    "Mode": "rw",
+                    "RW": True,
+                }
+            ]
+        }
+
+        volumes, error = system_update._resolve_helper_status_volume(
+            fake_container,
+            "/config/system_update_result.json",
+        )
+
+        self.assertIsNone(volumes)
+        self.assertIn("无法为状态文件", error)
+
+    def test_run_docker_helper_executes_inline_python_against_target_mount(self):
         fake_client = mock.Mock()
         fake_client.containers.run.return_value = b"ok"
         fake_client.images.get.return_value = object()
+        fake_target_container = mock.Mock()
+        fake_target_container.attrs = {
+            "Mounts": [
+                {
+                    "Type": "bind",
+                    "Source": "/srv/etk-config",
+                    "Destination": "/config",
+                    "Mode": "rw",
+                    "RW": True,
+                }
+            ]
+        }
+        fake_client.containers.get.return_value = fake_target_container
 
-        with mock.patch.object(system_update, "_get_update_status_path", return_value="/tmp/system_update_result.json"):
+        with mock.patch.object(system_update, "_get_update_status_path", return_value="/config/system_update_result.json"):
             with mock.patch.object(system_update, "_read_json_file", return_value={"ok": True, "message": "done"}):
-                with mock.patch("tempfile.NamedTemporaryFile") as tmp_file:
-                    tmp_cm = mock.MagicMock()
-                    tmp_cm.__enter__.return_value.name = "/tmp/helper.py"
-                    tmp_cm.__enter__.return_value.write.return_value = None
-                    tmp_cm.__exit__.return_value = False
-                    tmp_file.return_value = tmp_cm
-                    with mock.patch("os.makedirs"), mock.patch("os.remove", side_effect=FileNotFoundError()):
-                        events = list(system_update._run_docker_helper(
-                            fake_client,
-                            "hbq0405/emby-toolkit:latest",
-                            "emby-toolkit",
-                            "hbq0405/emby-toolkit:latest",
-                            {"current_version": "10.2.8", "target_version": "v10.2.9"},
-                        ))
+                with mock.patch("os.makedirs"), mock.patch("os.remove", side_effect=FileNotFoundError()):
+                    events = list(system_update._run_docker_helper(
+                        fake_client,
+                        "hbq0405/emby-toolkit:latest",
+                        "emby-toolkit",
+                        "hbq0405/emby-toolkit:latest",
+                        {"current_version": "10.2.8", "target_version": "v10.2.9"},
+                    ))
 
         self.assertTrue(events)
         _, kwargs = fake_client.containers.run.call_args
-        self.assertEqual(kwargs["entrypoint"], ["python"])
-        self.assertEqual(kwargs["command"], ["/tmp/etk_update_helper.py"])
+        self.assertEqual(kwargs["entrypoint"][0:2], ["python", "-c"])
+        self.assertIn("if __name__ == \"__main__\":", kwargs["entrypoint"][2])
+        self.assertNotIn("/tmp/etk_update_helper.py", kwargs["entrypoint"][2])
+        self.assertEqual(kwargs["volumes"]["/srv/etk-config"], {"bind": "/config", "mode": "rw"})
+        self.assertEqual(kwargs["environment"]["ETK_UPDATE_STATUS_PATH"], "/config/system_update_result.json")
+
+    def test_run_docker_helper_fails_fast_when_status_path_is_not_persisted_mount(self):
+        fake_client = mock.Mock()
+        fake_client.images.get.return_value = object()
+        fake_target_container = mock.Mock()
+        fake_target_container.attrs = {"Mounts": []}
+        fake_client.containers.get.return_value = fake_target_container
+
+        with mock.patch.object(system_update, "_get_update_status_path", return_value="/tmp/system_update_result.json"):
+            with mock.patch("os.makedirs"), mock.patch("os.remove", side_effect=FileNotFoundError()):
+                events = list(system_update._run_docker_helper(
+                    fake_client,
+                    "hbq0405/emby-toolkit:latest",
+                    "emby-toolkit",
+                    "hbq0405/emby-toolkit:latest",
+                    {"current_version": "10.3.0", "target_version": "v10.3.1"},
+                ))
+
+        self.assertEqual(events[-1]["event"], "ERROR")
+        self.assertIn("无法为状态文件", events[-1]["status"])
+        fake_client.containers.run.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
问题背景

系统自动更新在 Docker 环境下仍可能失败，典型报错为：

```text
启动 Docker Helper 失败: Command '['/tmp/etk_update_helper.py']' in image 'hbq0405/emby-toolkit:latest' returned non-zero exit status 1: b"/usr/local/bin/python: can't find '__main__' module in '/tmp/etk_update_helper.py'\n"
```

根因分析

之前的实现仍依赖把当前容器里的临时脚本路径 `/tmp/etk_update_helper.py` 挂载到 helper 容器中执行。
但自动更新是通过 `docker.sock` 启动 helper 容器的，此时 helper 容器看到的是 Docker 守护进程所在主机的挂载视角，而不是当前容器内部的临时文件系统。
因此：
- 当前容器里的 `/tmp/etk_update_helper.py` 不一定是宿主机可见路径
- 当前进程计算出的状态文件路径也不一定能直接被 helper 容器复用
- 最终会在 helper 容器启动阶段报 `can't find '__main__' module`

本次修复

1. 去掉对临时脚本 bind mount 的依赖
- 不再生成 `/tmp/etk_update_helper.py`
- helper 改为使用 `python -c` 直接执行内联脚本
- 彻底绕过临时脚本路径在宿主机不可见的问题

2. 从目标容器真实 Mounts 中解析状态文件持久化挂载
- 根据目标容器的 `Mounts` 反推 `/config/system_update_result.json` 对应的宿主挂载
- 仅在状态文件位于可写持久化挂载时才允许 helper 启动
- 对以下情况提前失败并返回清晰错误：
  - 状态路径不在持久化挂载内
  - 挂载是 `tmpfs`
  - 挂载源缺失
  - 挂载为只读

3. 提升入口健壮性
- `task_check_and_update_container()` 不再硬依赖 `logger.trace`
- 在非完整主启动路径或独立 runner 环境下，可回退到 `debug`，避免验证环境直接崩溃

测试覆盖

新增/调整了以下回归测试：
- 正常从目标容器挂载解析状态卷
- 状态路径不在持久化挂载内时快速失败
- helper 启动时使用 `python -c`，不再依赖 `/tmp/etk_update_helper.py`
- `logger` 没有 `trace` 方法时，更新入口仍可正常执行

验证结果

代码级验证：
```bash
python -m py_compile tasks/system_update.py tests/test_telegram_system_update_notification.py tests/test_system_update_post_notify.py
python -m unittest tests.test_telegram_system_update_notification tests.test_system_update_post_notify
git diff --check
git etk-pr-check
```

本地 Docker 端到端验证：
- 在 Mac 本地搭建了隔离 ETK 沙箱和本地 registry
- 实际完成了一次“旧容器 -> helper 接管 -> 新容器重建 -> 健康检查通过 -> 状态文件写回 -> 新容器消费结果”的完整链路验证
- 验证结果：
  - helper 以 `python -c` 启动
  - 不再依赖 `/tmp/etk_update_helper.py`
  - 更新结果成功写入 `/config/system_update_result.json`
  - 旧 image id：`sha256:6dd5b2865b62...`
  - 新 image id：`sha256:b1d3bcc3de49...`

Unraid live 只读取证：
- live 容器名：`emby-toolkit`
- live 镜像：`hbq0405/emby-toolkit:latest`
- live 关键环境：
  - `APP_DATA_DIR=/config`
  - `CONTAINER_NAME=emby-toolkit`
  - `DOCKER_IMAGE_NAME=hbq0405/emby-toolkit:latest`
- live 关键挂载：
  - `/mnt/user/appdata/embytoolkit -> /config`
  - `/var/run/docker.sock -> /var/run/docker.sock`

这说明本次修复依赖的运行时前提在 Unraid live 容器上成立。

影响范围

本次修改仅影响 Docker Helper 自动更新路径及其回归测试，不影响普通业务任务流程。
