### PR TITLE
修复 115 批量整理时 TG 集号污染整包文件

### DIFF
--- a/handler/p115_media_recognition.py
+++ b/handler/p115_media_recognition.py
@@ -35,6 +35,7 @@ def _install_test_stubs():
     sys.modules.setdefault("tasks.helpers", helpers_mod)
 
     tasks_pkg = types.ModuleType("tasks")
+    tasks_pkg.__path__ = [str(ROOT / "tasks")]
     tasks_pkg.helpers = helpers_mod
     sys.modules.setdefault("tasks", tasks_pkg)
 
@@ -47,6 +48,7 @@ def _install_test_stubs():
 
 _install_test_stubs()
 p115_service = importlib.import_module("handler.p115_service")
+task_p115 = importlib.import_module("tasks.p115")
 
 
 class P115RecognitionRuleTests(unittest.TestCase):
@@ -213,6 +215,179 @@ class P115RecognitionRuleTests(unittest.TestCase):
 
         self.assertEqual(season_num, 1)
         self.assertEqual(episode_num, 7)
+
+    def test_rename_file_node_prefers_file_episode_over_group_hint_episode(self):
+        organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
+        organizer.rename_config = {
+            "season_dir_format": ["season_name_en"],
+            "file_format": ["title_zh", "sep_space", "s_e"],
+        }
+        organizer.details = {"seasons": [], "last_episode_to_air": {}}
+        organizer.forced_season = None
+        organizer._fetch_and_parse_mediainfo = lambda *args, **kwargs: {
+            "season_number": 1,
+            "episode_number": 7,
+        }
+        organizer._extract_video_info = lambda *args, **kwargs: {}
+        organizer._parse_season_episode_by_custom_regex = lambda *args, **kwargs: (None, None, None)
+        organizer._build_name_from_format = lambda format_array, **kwargs: (
+            f"S{int(kwargs.get('season_num') or 0):02d}E{int(kwargs.get('episode_num') or 0):02d}"
+            if "s_e" in format_array else f"Season {int(kwargs.get('season_num') or 0):02d}"
+        )
+
+        _, season_num, episode_num, _, _, _, _ = organizer._rename_file_node(
+            {"fn": "Show.S01E07.mkv", "rel_path": "Show", "sha1": "abc123"},
+            new_base_name="Show",
+            is_tv=True,
+            original_title="Show",
+            silent_log=True,
+            recognition_hints={
+                "media_type": "tv",
+                "season_number": 1,
+                "episode_number": 8,
+                "confidence": "high",
+            },
+        )
+
+        self.assertEqual(season_num, 1)
+        self.assertEqual(episode_num, 7)
+
+    def test_rename_file_node_uses_group_hint_episode_when_local_evidence_missing(self):
+        organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
+        organizer.rename_config = {
+            "season_dir_format": ["season_name_en"],
+            "file_format": ["title_zh", "sep_space", "s_e"],
+        }
+        organizer.details = {"seasons": [], "last_episode_to_air": {}}
+        organizer.forced_season = None
+        organizer._fetch_and_parse_mediainfo = lambda *args, **kwargs: None
+        organizer._extract_video_info = lambda *args, **kwargs: {}
+        organizer._parse_season_episode_by_custom_regex = lambda *args, **kwargs: (None, None, None)
+        organizer._build_name_from_format = lambda format_array, **kwargs: (
+            f"S{int(kwargs.get('season_num') or 0):02d}E{int(kwargs.get('episode_num') or 0):02d}"
+            if "s_e" in format_array else f"Season {int(kwargs.get('season_num') or 0):02d}"
+        )
+
+        _, season_num, episode_num, _, _, _, _ = organizer._rename_file_node(
+            {"fn": "暗影蜘蛛侠.2026.WEB-DL.mkv", "rel_path": "暗影蜘蛛侠"},
+            new_base_name="暗影蜘蛛侠",
+            is_tv=True,
+            original_title="暗影蜘蛛侠",
+            silent_log=True,
+            recognition_hints={
+                "media_type": "tv",
+                "season_number": 1,
+                "episode_number": 8,
+                "confidence": "high",
+            },
+        )
+
+        self.assertEqual(season_num, 1)
+        self.assertEqual(episode_num, 8)
+
+    def test_rename_file_node_does_not_patch_raw_ffprobe_from_hint_only_episode(self):
+        organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
+        organizer.rename_config = {
+            "season_dir_format": ["season_name_en"],
+            "file_format": ["title_zh", "sep_space", "s_e"],
+        }
+        organizer.details = {"seasons": [], "last_episode_to_air": {}}
+        organizer.forced_season = None
+        organizer._fetch_and_parse_mediainfo = lambda *args, **kwargs: None
+        organizer._extract_video_info = lambda *args, **kwargs: {}
+        organizer._parse_season_episode_by_custom_regex = lambda *args, **kwargs: (None, None, None)
+        organizer._build_name_from_format = lambda format_array, **kwargs: (
+            f"S{int(kwargs.get('season_num') or 0):02d}E{int(kwargs.get('episode_num') or 0):02d}"
+            if "s_e" in format_array else f"Season {int(kwargs.get('season_num') or 0):02d}"
+        )
+
+        with mock.patch.object(p115_service.P115CacheManager, "patch_raw_ffprobe_etk_context") as patch_mock:
+            _, season_num, episode_num, _, _, _, _ = organizer._rename_file_node(
+                {"fn": "暗影蜘蛛侠.2026.WEB-DL.mkv", "rel_path": "暗影蜘蛛侠", "sha1": "abc123"},
+                new_base_name="暗影蜘蛛侠",
+                is_tv=True,
+                original_title="暗影蜘蛛侠",
+                silent_log=True,
+                recognition_hints={
+                    "media_type": "tv",
+                    "season_number": 1,
+                    "episode_number": 8,
+                    "confidence": "high",
+                },
+            )
+
+        self.assertEqual(season_num, 1)
+        self.assertEqual(episode_num, 8)
+        patch_mock.assert_not_called()
+
+    def test_rename_file_node_patches_raw_ffprobe_when_episode_comes_from_local_evidence(self):
+        organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
+        organizer.rename_config = {
+            "season_dir_format": ["season_name_en"],
+            "file_format": ["title_zh", "sep_space", "s_e"],
+        }
+        organizer.details = {"seasons": [], "last_episode_to_air": {}}
+        organizer.forced_season = None
+        organizer._fetch_and_parse_mediainfo = lambda *args, **kwargs: None
+        organizer._extract_video_info = lambda *args, **kwargs: {}
+        organizer._parse_season_episode_by_custom_regex = lambda *args, **kwargs: (None, None, None)
+        organizer._build_name_from_format = lambda format_array, **kwargs: (
+            f"S{int(kwargs.get('season_num') or 0):02d}E{int(kwargs.get('episode_num') or 0):02d}"
+            if "s_e" in format_array else f"Season {int(kwargs.get('season_num') or 0):02d}"
+        )
+
+        with mock.patch.object(p115_service.P115CacheManager, "patch_raw_ffprobe_etk_context") as patch_mock:
+            _, season_num, episode_num, _, _, _, _ = organizer._rename_file_node(
+                {"fn": "Show.S01E07.mkv", "rel_path": "Show", "sha1": "abc123"},
+                new_base_name="Show",
+                is_tv=True,
+                original_title="Show",
+                silent_log=True,
+                recognition_hints={
+                    "media_type": "tv",
+                    "season_number": 1,
+                    "episode_number": 8,
+                    "confidence": "high",
+                },
+            )
+
+        self.assertEqual(season_num, 1)
+        self.assertEqual(episode_num, 7)
+        patch_mock.assert_called_once_with("abc123", season_number=1, episode_number=7)
+
+    def test_normalize_batch_recognition_hints_drops_group_episode_for_tv(self):
+        hints = task_p115._normalize_batch_recognition_hints(
+            {
+                "tmdb_id": "220102",
+                "media_type": "tv",
+                "identify_title": "暗影蜘蛛侠",
+                "season_number": 1,
+                "episode_number": 8,
+                "confidence": "high",
+            },
+            is_tv=True,
+        )
+
+        self.assertEqual(hints["tmdb_id"], "220102")
+        self.assertEqual(hints["season_number"], 1)
+        self.assertNotIn("episode_number", hints)
+
+    def test_normalize_batch_recognition_hints_drops_season_episode_for_movie(self):
+        hints = task_p115._normalize_batch_recognition_hints(
+            {
+                "tmdb_id": "693134",
+                "media_type": "movie",
+                "identify_title": "Dune Part Two",
+                "season_number": 1,
+                "episode_number": 8,
+                "confidence": "high",
+            },
+            is_tv=False,
+        )
+
+        self.assertEqual(hints["tmdb_id"], "693134")
+        self.assertNotIn("season_number", hints)
+        self.assertNotIn("episode_number", hints)
 
 
 if __name__ == "__main__":

--- a/handler/p115_service.py
+++ b/handler/p115_service.py
@@ -3602,9 +3602,12 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                         video_info[k] = v
                     
         # 解析季集号
-        # ★ 优先使用 Webhook 强塞进来的精准数据，其次直接吃 raw_ffprobe_json 顶层 _etk 的季集号。
+        # ★ 优先使用文件级精准数据（Webhook 强塞 / raw_ffprobe / 文件名与路径显式特征），
+        #   TG Candidate hints 仅在本地证据缺失时做兜底，避免群组级集号污染整包文件。
         season_num = file_node.get('_forced_season')
         episode_num = file_node.get('_forced_episode')
+        season_source = 'forced' if season_num is not None else None
+        episode_source = 'forced' if episode_num is not None else None
 
         def _se_int(value):
             try:
@@ -3614,31 +3617,25 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
             except Exception:
                 return None
 
+        hint_season = _se_int(normalized_hints.get('season_number')) if normalized_hints else None
+        hint_episode = _se_int(normalized_hints.get('episode_number')) if normalized_hints else None
+
         if is_tv and real_info:
+            raw_probe_season = _se_int(real_info.get('season_number'))
+            raw_probe_episode = _se_int(real_info.get('episode_number'))
             if season_num is None:
-                season_num = _se_int(real_info.get('season_number'))
+                season_num = raw_probe_season
+                if raw_probe_season is not None:
+                    season_source = 'raw_ffprobe'
             if episode_num is None:
-                episode_num = _se_int(real_info.get('episode_number'))
-            if (real_info.get('season_number') not in (None, '') or real_info.get('episode_number') not in (None, '')) and not silent_log:
+                episode_num = raw_probe_episode
+                if raw_probe_episode is not None:
+                    episode_source = 'raw_ffprobe'
+            if (raw_probe_season is not None or raw_probe_episode is not None) and not silent_log:
                 logger.info(
                     f"  ➜ [raw_ffprobe季集号] 命中缓存身份 -> "
-                    f"S{int(season_num if season_num is not None else 1):02d}"
-                    f"E{int(episode_num if episode_num is not None else 0):02d} | {original_name}"
-                )
-
-        if is_tv and normalized_hints:
-            if season_num is None and normalized_hints.get('season_number') is not None:
-                season_num = _se_int(normalized_hints.get('season_number'))
-            if episode_num is None and normalized_hints.get('episode_number') is not None:
-                episode_num = _se_int(normalized_hints.get('episode_number'))
-            if (
-                (normalized_hints.get('season_number') not in (None, '') or normalized_hints.get('episode_number') not in (None, ''))
-                and not silent_log
-            ):
-                logger.info(
-                    f"  ➜ [TG Candidate季集] 命中 hints -> "
-                    f"S{int(season_num if season_num is not None else 1):02d}"
-                    f"E{int(episode_num if episode_num is not None else 0):02d} | {original_name}"
+                    f"S{int(raw_probe_season if raw_probe_season is not None else 1):02d}"
+                    f"E{int(raw_probe_episode if raw_probe_episode is not None else 0):02d} | {original_name}"
                 )
 
         if is_tv and (season_num is None or episode_num is None):
@@ -3651,8 +3648,10 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
 
             if custom_season is not None and season_num is None:
                 season_num = custom_season
+                season_source = 'custom_rule'
             if custom_episode is not None and episode_num is None:
                 episode_num = custom_episode
+                episode_source = 'custom_rule'
 
             if custom_rule_name and not silent_log:
                 logger.info(
@@ -3662,8 +3661,10 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
 
             if rule_result.get('season_number') is not None and season_num is None:
                 season_num = int(rule_result.get('season_number'))
+                season_source = 'rule'
             if rule_result.get('episode_number') is not None and episode_num is None:
                 episode_num = int(rule_result.get('episode_number'))
+                episode_source = 'rule'
             if (
                 (rule_result.get('season_number') is not None or rule_result.get('episode_number') is not None)
                 and not silent_log
@@ -3693,6 +3694,8 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
 
                     if season_num is None:
                         season_num = int(s) if s else None
+                        if season_num is not None:
+                            season_source = 'filename'
 
                     if episode_num is None:
                         episode_num = int(e) if e else (
@@ -3700,18 +3703,22 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                                 int(e_only) if e_only else int(zh_ep)
                             )
                         )
+                        if episode_num is not None:
+                            episode_source = 'filename'
 
             # 2. 从相对路径提取季号，支持 Specials / SP / OVA / 第0季
             if season_num is None and rel_path:
                 season_from_path = self._extract_season_from_path_or_text(rel_path)
                 if season_from_path is not None:
                     season_num = season_from_path
+                    season_source = 'path'
 
             # 3. ★ 纯数字 / 动漫数字兜底提取集号
             if episode_num is None:
                 name_without_ext = original_name.rsplit('.', 1)[0]
                 if name_without_ext.isdigit():
                     episode_num = int(name_without_ext)
+                    episode_source = 'filename'
                 else:
                     clean_name = re.sub(
                         r'(19|20)\d{2}|1080[pP]?|2160[pP]?|720[pP]?|480[pP]?|4[kK]|264|265|10bit|8bit|5\.1|7\.1|2\.0',
@@ -3723,30 +3730,52 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                     if anime_match:
                         ep_str = anime_match.group(1) or anime_match.group(2) or anime_match.group(3)
                         episode_num = int(ep_str)
+                        episode_source = 'filename'
                     else:
                         end_match = re.search(r'(?:^|[ \.\-\_\[\(])(\d{1,4})(?:[\]\)]|\s*)$', clean_name)
                         if end_match:
                             episode_num = int(end_match.group(1))
+                            episode_source = 'filename'
                         else:
                             mid_match = re.search(r'(?:^|[ \-\_\[\(])(\d{1,4})(?:[ \.\-\_\]\)]|$)', clean_name)
-                            if mid_match:
-                                episode_num = int(mid_match.group(1))
+                    if mid_match:
+                        episode_num = int(mid_match.group(1))
+                        episode_source = 'filename'
 
             # 4. 终极兜底
             if season_num is None:
                 season_num = 1
+                season_source = 'default'
+
+        if is_tv and normalized_hints:
+            if season_num is None and hint_season is not None:
+                season_num = hint_season
+                season_source = 'hint'
+            if episode_num is None and hint_episode is not None:
+                episode_num = hint_episode
+                episode_source = 'hint'
+            if (hint_season is not None or hint_episode is not None) and not silent_log:
+                logger.info(
+                    f"  ➜ [TG Candidate季集] 命中 hints -> "
+                    f"S{int(hint_season if hint_season is not None else 1):02d}"
+                    f"E{int(hint_episode if hint_episode is not None else 0):02d} | {original_name}"
+                )
 
         if is_tv and normalized_hints.get('is_special') and season_num is None:
             season_num = 0
+            season_source = 'hint'
 
         if is_tv and normalized_hints.get('is_special') and season_num == 1 and episode_num is None:
             season_num = 0
+            season_source = 'hint'
 
         if is_tv and rule_result.get('is_special') and season_num is None:
             season_num = 0
+            season_source = 'rule'
 
         if is_tv and rule_result.get('is_special') and season_num == 1 and episode_num is None:
             season_num = 0
+            season_source = 'rule'
 
         # ★★★ 动漫绝对集数转季号逻辑 (解决海贼王 S01E1158 的问题) ★★★
         if is_tv and episode_num is not None and episode_num > 30:
@@ -3767,6 +3796,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                 # 捷径：如果是最新集，直接取最新季
                 if last_ep_data and last_ep_data.get('episode_number') == episode_num:
                     season_num = last_ep_data.get('season_number', 1)
+                    season_source = 'season_capacity_fix'
                     if not silent_log:
                         logger.info(f"  ➜ [分季修正] 命中最新集，自动修正为第 {season_num} 季")
                 elif seasons_data:
@@ -3777,6 +3807,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                         cumulative += s.get('episode_count', 0)
                         if episode_num <= cumulative:
                             season_num = s['season_number']
+                            season_source = 'season_capacity_fix'
                             if not silent_log:
                                 logger.info(f"  ➜ [分季修正] 绝对集数 {episode_num} 超出原季容量，已自动推算并修正为第 {season_num} 季！")
                             break
@@ -3801,6 +3832,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                     
                 if not has_explicit_season:
                     season_num = int(self.forced_season)
+                    season_source = 'forced'
 
         # ★★★ 核心升级：直接调用统一乐高引擎生成文件名 ★★★
         default_format = ['title_zh', 'sep_dash_space', 'year', 'sep_middot_space', 's_e', 'sep_middot_space', 'resolution', 'sep_middot_space', 'codec', 'sep_middot_space', 'audio', 'sep_middot_space', 'group']
@@ -3848,11 +3880,16 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
         if is_tv and not is_sub:
             try:
                 raw_patch_sha1 = file_node.get('sha1') or file_node.get('sha')
-                if raw_patch_sha1 and (season_num is not None or episode_num is not None):
+                trusted_season = season_num if (
+                    season_source not in (None, 'hint')
+                    and episode_source not in ('hint',)
+                ) else None
+                trusted_episode = episode_num if episode_source not in (None, 'hint') else None
+                if raw_patch_sha1 and (trusted_season is not None or trusted_episode is not None):
                     P115CacheManager.patch_raw_ffprobe_etk_context(
                         raw_patch_sha1,
-                        season_number=season_num,
-                        episode_number=episode_num,
+                        season_number=trusted_season,
+                        episode_number=trusted_episode,
                     )
             except Exception:
                 pass

--- a/tasks/p115.py
+++ b/tasks/p115.py
@@ -26,7 +26,7 @@ from handler.p115_service import (
     _identify_media_enhanced
 )
 from handler.p115_media_analyzer import P115MediaAnalyzerMixin
-from handler.tg_media_candidate import lookup_candidate_hint_for_name
+from handler.tg_media_candidate import candidate_to_recognition_hints, lookup_candidate_hint_for_name
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +52,31 @@ GENERIC_PACKAGE_SEGMENT_RE = re.compile(
 KNOWN_VIDEO_EXTS = {'mp4', 'mkv', 'avi', 'ts', 'iso', 'rmvb', 'wmv', 'mov', 'm2ts', 'flv', 'mpg'}
 KNOWN_SKIP_EXTS = {'clpi', 'mpls', 'bdmv', 'jar', 'bup', 'ifo'}
 MIN_BIG_PACKAGE_VIDEO_SIZE = 50 * 1024 * 1024
+
+
+def _normalize_batch_recognition_hints(hints, *, is_tv=False, preserve_episode=False):
+    """
+    批量整理时，组级 hints 只能安全复用标题/TMDb/季级信息。
+
+    单条 TG 候选携带的 episode_number 往往只代表“频道消息里展示的最新集”，
+    不能直接灌给整包中的每个文件；否则 E08 可能污染同批的 E05/E06/E07。
+    """
+    normalized = candidate_to_recognition_hints(hints or {})
+    if not normalized:
+        return {}
+
+    normalized = dict(normalized)
+
+    if not is_tv:
+        normalized.pop("season_number", None)
+        normalized.pop("episode_number", None)
+        normalized.pop("is_special", None)
+        return normalized
+
+    if not preserve_episode:
+        normalized.pop("episode_number", None)
+
+    return normalized
 
 
 def _name_has_tv_hint(name):
@@ -192,12 +217,12 @@ def _build_filewise_big_package_groups(gathered_files, top_name, ai_translator=N
         context_name = _choose_big_package_context_name(top_name, rel_dir)
         forced_type = 'tv' if (_name_has_tv_hint(file_name) or _name_has_tv_hint(rel_dir)) else None
         season_num = _extract_season_number(file_name, rel_dir, context_name)
-        recognition_hints = lookup_candidate_hint_for_name(
+        recognition_hints = _normalize_batch_recognition_hints(lookup_candidate_hint_for_name(
             file_name,
             alt_texts=[context_name, top_name],
             media_type=forced_type,
             season_number=season_num,
-        )
+        ), is_tv=(forced_type == 'tv'))
         file_sha1 = video_item.get('sha1') or video_item.get('sha')
         tmdb_id, media_type, title = _identify_media_enhanced(
             file_name,
@@ -529,7 +554,10 @@ def task_scan_and_organize_115(processor=None):
                             if group_sha1:
                                 break
 
-                    recognition_hints = lookup_candidate_hint_for_name(g_top_name, alt_texts=[top_name], media_type=forced_type)
+                    recognition_hints = _normalize_batch_recognition_hints(
+                        lookup_candidate_hint_for_name(g_top_name, alt_texts=[top_name], media_type=forced_type),
+                        is_tv=(forced_type == 'tv')
+                    )
                     tmdb_id, media_type, title = _identify_media_enhanced(
                         g_top_name, main_dir_name=g_top_name, has_season_subdirs=group["has_season_dir"],
                         forced_media_type=forced_type, ai_translator=ai_translator, use_ai=use_ai, is_folder=False,
@@ -544,7 +572,10 @@ def task_scan_and_organize_115(processor=None):
                     
                 try:
                     organizer = SmartOrganizer(client, tmdb_id, media_type, title, ai_translator, use_ai)
-                    organizer.recognition_hints = recognition_hints or {}
+                    organizer.recognition_hints = _normalize_batch_recognition_hints(
+                        recognition_hints,
+                        is_tv=(media_type == 'tv')
+                    )
                     if season_num is not None: organizer.forced_season = season_num
                     
                     # 执行整理 (直接传 None，让 execute 内部统一计算最终的 target_cid)


### PR DESCRIPTION
## 变更说明
- 修正 115 批量整理时组级 TG hints 可能把单个集号污染到整包文件的问题
- 调整季集号优先级：优先使用文件级证据，TG hints 仅在本地证据缺失时兜底
- 避免仅由 hints 推导出的季集号反写进 raw_ffprobe `_etk` 缓存，减少错误缓存固化
- 为批量整理入口新增 hints 归一化，TV 组级 hints 默认剔除 `episode_number`
- 补充回归测试，覆盖文件级证据优先、hints 兜底和缓存回写边界

## 验证
- `python -m py_compile handler/p115_service.py handler/p115_media_recognition.py tasks/p115.py`
- `python -m unittest handler.p115_media_recognition`
- `git diff --check -- handler/p115_service.py handler/p115_media_recognition.py tasks/p115.py`
- live 环境实测影巢资源 `梦魇绝镇 (2022)` `152.02GB`：S01-S03 共 30 集正确入库，未复现整包被同一集号污染的问题
