### PR TITLE
修复外挂字幕未跟随视频文件重命名

### DIFF
--- a/handler/p115_media_recognition.py
+++ b/handler/p115_media_recognition.py
@@ -32,6 +32,8 @@ def _install_test_stubs():
 
     helpers_mod = types.ModuleType("tasks.helpers")
     helpers_mod.check_series_completion = lambda *args, **kwargs: False
+    helpers_mod.normalize_lang_code = lambda value, *args, **kwargs: value
+    helpers_mod._get_detected_languages_from_streams = lambda *args, **kwargs: set()
     sys.modules.setdefault("tasks.helpers", helpers_mod)
 
     tasks_pkg = types.ModuleType("tasks")
@@ -44,6 +46,14 @@ def _install_test_stubs():
         pass
     analyzer_mod.P115MediaAnalyzerMixin = _Mixin
     sys.modules.setdefault("handler.p115_media_analyzer", analyzer_mod)
+
+    resubscribe_mod = types.ModuleType("handler.resubscribe_service")
+    class _WashingService:
+        @staticmethod
+        def decide_washing_action(*args, **kwargs):
+            return "ACCEPT", "stub"
+    resubscribe_mod.WashingService = _WashingService
+    sys.modules.setdefault("handler.resubscribe_service", resubscribe_mod)
 
 
 _install_test_stubs()
@@ -118,6 +128,134 @@ class P115RecognitionRuleTests(unittest.TestCase):
         self.assertEqual(media_type, "movie")
         self.assertEqual(title, "Some Movie")
         details_mock.assert_called_once_with("123456", "fake")
+
+    def test_rename_file_node_uses_original_video_basename_for_subtitles_when_keep_original(self):
+        organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
+        organizer.rename_config = {}
+        organizer.media_type = "tv"
+        organizer.forced_season = 1
+        organizer.details = {}
+        organizer.raw_metadata = {}
+        organizer.recognition_hints = {}
+        organizer._build_name_from_format = mock.Mock(return_value="Season 01")
+
+        subtitle = {
+            "fn": "Predators.(2019).S01E01.WEB-DL.HDR.DV.2160p.HEVC.Atmos.5.1.NF.ass",
+            "_forced_base_name": "Predators (2019) - S01E01 - WEB-DL - HDR10 DoVi P8 - 2160p - HEVC 10bit - DDP 5.1 - NF - Sic",
+            "_forced_season": 1,
+            "_forced_episode": 1,
+        }
+
+        new_name, season_num, episode_num, season_dir, _, _, _ = organizer._rename_file_node(
+            subtitle,
+            "Predators (2019)",
+            is_tv=True,
+            original_title="Predators",
+            silent_log=True,
+            recognition_hints={},
+        )
+
+        self.assertEqual(
+            new_name,
+            "Predators (2019) - S01E01 - WEB-DL - HDR10 DoVi P8 - 2160p - HEVC 10bit - DDP 5.1 - NF - Sic.ass",
+        )
+        self.assertEqual(season_num, 1)
+        self.assertEqual(episode_num, 1)
+        self.assertEqual(season_dir, "Season 01")
+
+    def test_execute_keeps_video_original_name_but_renames_sidecar_subtitle_to_video_basename(self):
+        organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
+        organizer.client = mock.Mock()
+        organizer.client.fs_move.return_value = {"state": True}
+        organizer.client.fs_rename_batch.return_value = {"state": True, "_rename_failures": {}}
+        organizer.client.fs_files.return_value = {"state": True, "data": [], "path": []}
+        organizer.tmdb_id = "1"
+        organizer.media_type = "tv"
+        organizer.original_title = "Predators"
+        organizer.ai_translator = None
+        organizer.use_ai = False
+        organizer.api_key = "fake"
+        organizer.forced_season = 1
+        organizer.recognition_hints = {}
+        organizer.raw_metadata = {"lang_code": "en"}
+        organizer.details = {"title": "Predators", "original_title": "Predators", "date": "2019-01-01", "seasons": []}
+        organizer.rules = [{"cid": "999", "dir_name": "欧美剧", "category_path": "电视剧/欧美剧"}]
+        organizer.rename_config = {
+            "keep_original_name": True,
+            "season_dir_format": ["season_name_en"],
+            "main_dir_format": ["title_zh"],
+        }
+        organizer._fetch_raw_metadata = mock.Mock(return_value={})
+        organizer.get_target_cid = mock.Mock(return_value="999")
+        organizer._fetch_and_parse_mediainfo = mock.Mock(return_value=None)
+        organizer._extract_video_info = mock.Mock(return_value={})
+        organizer._parse_season_episode_by_custom_regex = mock.Mock(return_value=(None, None, None))
+        organizer._extract_season_from_path_or_text = mock.Mock(return_value=1)
+        organizer._build_name_from_format = mock.Mock(side_effect=lambda format_array, **kwargs: (
+            "Season 01" if format_array == ["season_name_en"] else "Predators (2019)"
+        ))
+
+        def fake_rename(file_item, *_args, **_kwargs):
+            name = file_item["fn"]
+            if name.endswith(".mkv"):
+                return name, 1, 1, "Season 01", {}, False, None
+            forced_base = file_item.get("_forced_base_name")
+            return f"{forced_base}.ass", 1, 1, "Season 01", {}, False, None
+
+        organizer._rename_file_node = mock.Mock(side_effect=fake_rename)
+
+        candidates = [
+            {
+                "fid": "v1",
+                "file_id": "v1",
+                "fn": "Predators.(2019).S01E01.WEB-DL.HDR10.DoVi.P8.2160p.HEVC.10bit.DDP.5.1.NF-Sic.mkv",
+                "fc": "1",
+                "pid": "src1",
+                "pc": "pcv1",
+                "sha1": "sha-v1",
+                "fs": str(7 * 1024 * 1024 * 1024),
+            },
+            {
+                "fid": "s1",
+                "file_id": "s1",
+                "fn": "Predators.(2019).S01E01.WEB-DL.HDR.DV.2160p.HEVC.Atmos.5.1.NF.ass",
+                "fc": "1",
+                "pid": "src1",
+                "pc": "pcs1",
+                "fs": "102400",
+            },
+        ]
+
+        fake_config = {
+            p115_service.constants.CONFIG_OPTION_115_MEDIA_ROOT_CID: "1",
+            p115_service.constants.CONFIG_OPTION_115_UNRECOGNIZED_CID: "998",
+            p115_service.constants.CONFIG_OPTION_115_MIN_VIDEO_SIZE: 10,
+            p115_service.constants.CONFIG_OPTION_115_EXTENSIONS: [],
+            p115_service.constants.CONFIG_OPTION_LOCAL_STRM_ROOT: "",
+            p115_service.constants.CONFIG_OPTION_ETK_SERVER_URL: "http://127.0.0.1:5257",
+            p115_service.constants.CONFIG_OPTION_115_DOWNLOAD_SUBS: True,
+            p115_service.constants.CONFIG_OPTION_115_GENERATE_MEDIAINFO: False,
+        }
+
+        with mock.patch.object(p115_service, "get_config", return_value=fake_config):
+            with mock.patch.object(p115_service.P115CacheManager, "get_cid", return_value=None):
+                with mock.patch.object(p115_service.P115CacheManager, "save_cid", return_value=None):
+                    with mock.patch.object(p115_service.P115CacheManager, "update_local_path", return_value=None):
+                        with mock.patch.object(p115_service.P115CacheManager, "save_file_cache", return_value=None):
+                            with mock.patch.object(p115_service.P115RecordManager, "add_or_update_record", return_value=None):
+                                with mock.patch.object(p115_service, "get_db_connection", side_effect=RuntimeError("db not used")):
+                                    ok = organizer.execute(candidates, None, skip_gc=True)
+
+        self.assertTrue(ok)
+        organizer.client.fs_rename_batch.assert_called_once()
+        rename_pairs = organizer.client.fs_rename_batch.call_args.args[0]
+        self.assertIn(
+            (
+                "s1",
+                "Predators.(2019).S01E01.WEB-DL.HDR10.DoVi.P8.2160p.HEVC.10bit.DDP.5.1.NF-Sic.ass",
+            ),
+            rename_pairs,
+        )
 
     def test_identify_media_enhanced_prefers_raw_ffprobe_identity_over_rule_tmdbid(self):
         raw_ffprobe_json = {

--- a/handler/p115_service.py
+++ b/handler/p115_service.py
@@ -4520,7 +4520,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
         # ★★★ 同批次字幕完美对齐视频命名 (解决 MP 单文件上传分离问题) ★★★
         # =================================================================
         batch_video_names = {} # key: (season, episode, part) -> base_name
-        if not keep_original and is_batch:
+        if is_batch:
             # 1. 预扫描视频，生成标准命名
             for file_item in candidates:
                 fn = file_item.get('fn') or file_item.get('n') or file_item.get('file_name', '')
@@ -4534,10 +4534,13 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                         silent_log=True,  # ★ 开启静默，防止预扫描时重复打印日志
                         recognition_hints=self.recognition_hints,
                     )
+                    video_base_name = fn.rsplit('.', 1)[0]
+                    if not keep_original:
+                        video_base_name = v_name.rsplit('.', 1)[0]
                     key = (v_s, v_e, v_part) if self.media_type == 'tv' else ('movie', v_part)
                     # 电影只保留第一个视频作为基准 (通常电影只有一个正片)
                     if key not in batch_video_names:
-                        batch_video_names[key] = v_name.rsplit('.', 1)[0]
+                        batch_video_names[key] = video_base_name
             
             # 2. 将视频基础名注入到同批次的字幕中
             if batch_video_names:
@@ -4698,8 +4701,12 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                     recognition_hints=self.recognition_hints,
                 )
 
-                # ★ 核心：只保留文件名
-                new_filename = file_name
+                # ★ 核心：保留原名只对主视频生效。
+                # 外挂字幕若已绑定到同批视频，仍需跟随视频基名改名，避免 Emby/Jellyfin 挂载失配。
+                if ext in ['srt', 'ass', 'ssa', 'sub', 'vtt', 'sup'] and file_item.get('_forced_base_name'):
+                    new_filename = parsed_filename
+                else:
+                    new_filename = file_name
 
                 # ★ 目录仍走标准逻辑
                 real_target_cid = final_home_cid
@@ -6810,6 +6817,73 @@ def _batch_manual_correct(record_ids, tmdb_id, media_type, target_cid, season_nu
             logger.warning(f"  ➜ 查找关联字幕失败: {e}")
 
     if sub_items:
+        if root_items:
+            subtitle_video_names = {}
+            for r_item in root_items:
+                info_name = (
+                    r_item.get('_new_filename')
+                    or (r_item.get('_info_data') or {}).get('file_name')
+                    or r_item.get('fn')
+                    or r_item.get('file_name')
+                    or ''
+                )
+                if not info_name:
+                    continue
+                season_key = _extract_season_number(info_name)
+                episode_key = None
+                match = re.search(
+                    r'(?:^|[ \.\-\_\[\(])(?:s|S)(\d{1,4})[ \.\-]*(?:e|E|p|P)(\d{1,4})\b'
+                    r'|(?:^|[ \.\-\_\[\(])(?:ep|episode)[ \.\-]*?(\d{1,4})\b'
+                    r'|(?:^|[ \.\-\_\[\(])e(\d{1,4})\b'
+                    r'|第(\d{1,4})[集话話回]',
+                    info_name,
+                    re.IGNORECASE,
+                )
+                if match:
+                    season_from_name = match.group(1)
+                    episode_key = match.group(2) or match.group(3) or match.group(4) or match.group(5)
+                    if season_key is None and season_from_name:
+                        season_key = int(season_from_name)
+                if episode_key is None:
+                    continue
+                try:
+                    episode_key = int(episode_key)
+                except Exception:
+                    continue
+                if season_key is None:
+                    season_key = organizer.forced_season or 1
+                subtitle_video_names[(int(season_key), int(episode_key))] = info_name.rsplit('.', 1)[0]
+
+            for sub_item in sub_items:
+                sub_name = sub_item.get('fn') or sub_item.get('n') or sub_item.get('file_name', '')
+                season_key = organizer.forced_season
+                episode_key = None
+                match = re.search(
+                    r'(?:^|[ \.\-\_\[\(])(?:s|S)(\d{1,4})[ \.\-]*(?:e|E|p|P)(\d{1,4})\b'
+                    r'|(?:^|[ \.\-\_\[\(])(?:ep|episode)[ \.\-]*?(\d{1,4})\b'
+                    r'|(?:^|[ \.\-\_\[\(])e(\d{1,4})\b'
+                    r'|第(\d{1,4})[集话話回]',
+                    sub_name,
+                    re.IGNORECASE,
+                )
+                if match:
+                    season_from_name = match.group(1)
+                    episode_key = match.group(2) or match.group(3) or match.group(4) or match.group(5)
+                    if season_key is None and season_from_name:
+                        season_key = int(season_from_name)
+                if episode_key is None:
+                    continue
+                try:
+                    episode_key = int(episode_key)
+                except Exception:
+                    continue
+                if season_key is None:
+                    season_key = 1
+                forced_base_name = subtitle_video_names.get((int(season_key), int(episode_key)))
+                if forced_base_name:
+                    sub_item['_forced_base_name'] = forced_base_name
+                    sub_item['_forced_season'] = int(season_key)
+                    sub_item['_forced_episode'] = int(episode_key)
         logger.info(f"  🔤 [批量重组] 发现 {len(sub_items)} 个关联字幕，跟随重组...")
         organizer.execute(sub_items, target_cid)
 


### PR DESCRIPTION
## 变更说明
- 修复批量整理时外挂字幕未跟随对应视频基名重命名的问题
- 修复 `keep_original_name` 开启时，视频保留原名但外挂字幕仍需对齐到视频基名的逻辑
- 修复手动重组链路里关联字幕二次执行时缺少视频基名映射，导致字幕按自身文件名独立重命名的问题
- 补充批量 `execute(...)` 模拟回归测试，覆盖 `mkv + ass` 同批整理场景

## 验证
- `python -m py_compile handler/p115_service.py handler/p115_media_recognition.py`
- `python -m unittest handler.p115_media_recognition`
- `git diff --check -- handler/p115_service.py handler/p115_media_recognition.py`

## 备注
- 本次 PR 仅包含字幕重命名修复相关文件，不包含本地未提交的其他改动
