### PR TITLE
补强外挂字幕关联与重命名匹配

### DIFF
--- a/handler/p115_media_recognition.py
+++ b/handler/p115_media_recognition.py
@@ -257,6 +257,38 @@ class P115RecognitionRuleTests(unittest.TestCase):
             rename_pairs,
         )
 
+    def test_tasks_related_sidecar_name_matches_same_episode_without_full_prefix(self):
+        self.assertTrue(
+            task_p115._is_related_sidecar_name(
+                "Predators.(2019).S01E01.WEB-DL.HDR10.DoVi.P8.2160p.HEVC.10bit.DDP.5.1.NF-Sic.mkv",
+                "Predators.(2019).S01E01.WEB-DL.HDR.DV.2160p.HEVC.Atmos.5.1.NF.ass",
+            )
+        )
+
+    def test_tasks_related_sidecar_name_rejects_different_episode(self):
+        self.assertFalse(
+            task_p115._is_related_sidecar_name(
+                "Predators.(2019).S01E01.WEB-DL.HDR10.DoVi.P8.2160p.HEVC.10bit.DDP.5.1.NF-Sic.mkv",
+                "Predators.(2019).S01E02.WEB-DL.HDR.DV.2160p.HEVC.Atmos.5.1.NF.ass",
+            )
+        )
+
+    def test_handler_related_sidecar_name_matches_same_episode_without_full_prefix(self):
+        self.assertTrue(
+            p115_service._is_related_sidecar_name(
+                "Predators.(2019).S01E01.WEB-DL.HDR10.DoVi.P8.2160p.HEVC.10bit.DDP.5.1.NF-Sic.mkv",
+                "Predators.(2019).S01E01.WEB-DL.HDR.DV.2160p.HEVC.Atmos.5.1.NF.ass",
+            )
+        )
+
+    def test_handler_related_sidecar_name_rejects_different_episode(self):
+        self.assertFalse(
+            p115_service._is_related_sidecar_name(
+                "Predators.(2019).S01E01.WEB-DL.HDR10.DoVi.P8.2160p.HEVC.10bit.DDP.5.1.NF-Sic.mkv",
+                "Predators.(2019).S01E02.WEB-DL.HDR.DV.2160p.HEVC.Atmos.5.1.NF.ass",
+            )
+        )
+
     def test_identify_media_enhanced_prefers_raw_ffprobe_identity_over_rule_tmdbid(self):
         raw_ffprobe_json = {
             "_etk": {

--- a/handler/p115_service.py
+++ b/handler/p115_service.py
@@ -79,6 +79,83 @@ _DIRECT_URL_CACHE = LimitedCache(maxsize=2000)
 _GLOBAL_DIR_CACHE = LimitedCache(maxsize=5000)
 _GLOBAL_DIR_LOCK = threading.Lock()
 
+
+def _extract_sidecar_episode_number(*texts):
+    for text in texts:
+        if not text:
+            continue
+        value = str(text)
+        match = re.search(
+            r'(?:^|[ \.\-\_\[\(])(?:s|S)(\d{1,4})[ \.\-]*(?:e|E|p|P)(\d{1,4})\b'
+            r'|(?:^|[ \.\-\_\[\(])(?:ep|episode)[ \.\-]*?(\d{1,4})\b'
+            r'|(?:^|[ \.\-\_\[\(])e(\d{1,4})\b'
+            r'|第(\d{1,4})[集话話回]',
+            value,
+            re.IGNORECASE,
+        )
+        if match:
+            episode = match.group(2) or match.group(3) or match.group(4) or match.group(5)
+            if episode is not None:
+                return int(episode)
+    return None
+
+
+def _extract_sidecar_part_number(*texts):
+    for text in texts:
+        if not text:
+            continue
+        value = str(text)
+        match = re.search(r'(?i)[ \.\-\_\[\(]*(part|pt|cd)[ \.\-\_]*(\d{1,2})\b', value)
+        if match:
+            return int(match.group(2))
+    return None
+
+
+def _extract_sidecar_season_number(*texts):
+    for text in texts:
+        if not text:
+            continue
+        value = str(text)
+        match = re.search(r'(?:^|[ \.\-\_\[\(])(?:s|S)(\d{1,4})(?:[ \.\-]*(?:e|E|p|P)\d{1,4}\b)?', value, re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+        match = re.search(r'Season\s*(\d{1,4})\b', value, re.IGNORECASE)
+        if match:
+            return int(match.group(1))
+        match = re.search(r'第(\d{1,4})季', value)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _is_related_sidecar_name(video_name, other_name):
+    video_name = str(video_name or '')
+    other_name = str(other_name or '')
+    if not video_name or not other_name:
+        return False
+
+    video_base = video_name.rsplit('.', 1)[0] if '.' in video_name else video_name
+    if other_name.startswith(video_base):
+        return True
+
+    video_season = _extract_sidecar_season_number(video_name)
+    other_season = _extract_sidecar_season_number(other_name)
+    video_episode = _extract_sidecar_episode_number(video_name)
+    other_episode = _extract_sidecar_episode_number(other_name)
+    video_part = _extract_sidecar_part_number(video_name)
+    other_part = _extract_sidecar_part_number(other_name)
+
+    if video_episode is None or other_episode is None:
+        return False
+
+    if video_season is not None and other_season is not None and video_season != other_season:
+        return False
+
+    if video_part is not None and other_part is not None and video_part != other_part:
+        return False
+
+    return video_episode == other_episode
+
 _NOISE_TOKEN_PATTERNS = [
     r'(?i)\b(?:WEB[-_. ]?DL|WEB[-_. ]?RIP|BLU[-_. ]?RAY|BDRIP|BRRIP|REMUX|DVDRIP|HDTV|UHD)\b',
     r'(?i)\b(?:HDR10\+?|HDR|DV|DOVI|DOLBY[.\s_-]*VISION|HLG)\b',
@@ -6809,8 +6886,7 @@ def _batch_manual_correct(record_ids, tmdb_id, media_type, target_cid, season_nu
                         # 检查是否匹配任何一个视频的基础名
                         for r_item in root_items:
                             v_name = r_item['_info_data'].get('file_name') or r_item['fn']
-                            v_base = v_name.rsplit('.', 1)[0] if '.' in v_name else v_name
-                            if sub_name.startswith(v_base):
+                            if _is_related_sidecar_name(v_name, sub_name):
                                 sub_items.append(item)
                                 break
         except Exception as e:
@@ -6829,57 +6905,27 @@ def _batch_manual_correct(record_ids, tmdb_id, media_type, target_cid, season_nu
                 )
                 if not info_name:
                     continue
-                season_key = _extract_season_number(info_name)
-                episode_key = None
-                match = re.search(
-                    r'(?:^|[ \.\-\_\[\(])(?:s|S)(\d{1,4})[ \.\-]*(?:e|E|p|P)(\d{1,4})\b'
-                    r'|(?:^|[ \.\-\_\[\(])(?:ep|episode)[ \.\-]*?(\d{1,4})\b'
-                    r'|(?:^|[ \.\-\_\[\(])e(\d{1,4})\b'
-                    r'|第(\d{1,4})[集话話回]',
-                    info_name,
-                    re.IGNORECASE,
-                )
-                if match:
-                    season_from_name = match.group(1)
-                    episode_key = match.group(2) or match.group(3) or match.group(4) or match.group(5)
-                    if season_key is None and season_from_name:
-                        season_key = int(season_from_name)
+                season_key = _extract_sidecar_season_number(info_name)
+                episode_key = _extract_sidecar_episode_number(info_name)
+                part_key = _extract_sidecar_part_number(info_name)
                 if episode_key is None:
-                    continue
-                try:
-                    episode_key = int(episode_key)
-                except Exception:
                     continue
                 if season_key is None:
                     season_key = organizer.forced_season or 1
-                subtitle_video_names[(int(season_key), int(episode_key))] = info_name.rsplit('.', 1)[0]
+                subtitle_video_names[(int(season_key), int(episode_key), part_key)] = info_name.rsplit('.', 1)[0]
 
             for sub_item in sub_items:
                 sub_name = sub_item.get('fn') or sub_item.get('n') or sub_item.get('file_name', '')
-                season_key = organizer.forced_season
-                episode_key = None
-                match = re.search(
-                    r'(?:^|[ \.\-\_\[\(])(?:s|S)(\d{1,4})[ \.\-]*(?:e|E|p|P)(\d{1,4})\b'
-                    r'|(?:^|[ \.\-\_\[\(])(?:ep|episode)[ \.\-]*?(\d{1,4})\b'
-                    r'|(?:^|[ \.\-\_\[\(])e(\d{1,4})\b'
-                    r'|第(\d{1,4})[集话話回]',
-                    sub_name,
-                    re.IGNORECASE,
-                )
-                if match:
-                    season_from_name = match.group(1)
-                    episode_key = match.group(2) or match.group(3) or match.group(4) or match.group(5)
-                    if season_key is None and season_from_name:
-                        season_key = int(season_from_name)
+                season_key = _extract_sidecar_season_number(sub_name)
+                episode_key = _extract_sidecar_episode_number(sub_name)
+                part_key = _extract_sidecar_part_number(sub_name)
                 if episode_key is None:
                     continue
-                try:
-                    episode_key = int(episode_key)
-                except Exception:
-                    continue
                 if season_key is None:
-                    season_key = 1
-                forced_base_name = subtitle_video_names.get((int(season_key), int(episode_key)))
+                    season_key = organizer.forced_season or 1
+                forced_base_name = subtitle_video_names.get((int(season_key), int(episode_key), part_key))
+                if not forced_base_name:
+                    forced_base_name = subtitle_video_names.get((int(season_key), int(episode_key), None))
                 if forced_base_name:
                     sub_item['_forced_base_name'] = forced_base_name
                     sub_item['_forced_season'] = int(season_key)

--- a/tasks/p115.py
+++ b/tasks/p115.py
@@ -108,6 +108,66 @@ def _extract_season_number(*texts):
     return None
 
 
+def _extract_episode_number(*texts):
+    for text in texts:
+        if not text:
+            continue
+        value = str(text)
+        match = re.search(
+            r'(?:^|[ \.\-\_\[\(])(?:s|S)(\d{1,4})[ \.\-]*(?:e|E|p|P)(\d{1,4})\b'
+            r'|(?:^|[ \.\-\_\[\(])(?:ep|episode)[ \.\-]*?(\d{1,4})\b'
+            r'|(?:^|[ \.\-\_\[\(])e(\d{1,4})\b'
+            r'|第(\d{1,4})[集话話回]',
+            value,
+            re.IGNORECASE,
+        )
+        if match:
+            episode = match.group(2) or match.group(3) or match.group(4) or match.group(5)
+            if episode is not None:
+                return int(episode)
+    return None
+
+
+def _extract_part_number(*texts):
+    for text in texts:
+        if not text:
+            continue
+        value = str(text)
+        match = re.search(r'(?i)[ \.\-\_\[\(]*(part|pt|cd)[ \.\-\_]*(\d{1,2})\b', value)
+        if match:
+            return int(match.group(2))
+    return None
+
+
+def _is_related_sidecar_name(video_name, other_name):
+    video_name = str(video_name or '')
+    other_name = str(other_name or '')
+    if not video_name or not other_name:
+        return False
+
+    video_base = video_name.rsplit('.', 1)[0] if '.' in video_name else video_name
+    if other_name.startswith(video_base):
+        return True
+
+    video_season = _extract_season_number(video_name)
+    other_season = _extract_season_number(other_name)
+    video_episode = _extract_episode_number(video_name)
+    other_episode = _extract_episode_number(other_name)
+    video_part = _extract_part_number(video_name)
+    other_part = _extract_part_number(other_name)
+
+    if video_episode is None or other_episode is None:
+        return False
+
+    if video_season is not None and other_season is not None and video_season != other_season:
+        return False
+
+    if video_part is not None and other_part is not None and video_part != other_part:
+        return False
+
+    return video_episode == other_episode
+
+
 def _is_generic_package_segment(name):
     if not name:
         return True
@@ -236,7 +296,6 @@ def _build_filewise_big_package_groups(gathered_files, top_name, ai_translator=N
             recognition_hints=recognition_hints,
         )
 
-        video_base = file_name.rsplit('.', 1)[0] if '.' in file_name else file_name
         related_items = [video_item]
         assigned_ids.add(video_fid)
 
@@ -248,7 +307,7 @@ def _build_filewise_big_package_groups(gathered_files, top_name, ai_translator=N
             other_dir = other_item.get('_etk_rel_dir', '')
             if other_dir != rel_dir:
                 continue
-            if other_name.startswith(video_base):
+            if _is_related_sidecar_name(file_name, other_name):
                 related_items.append(other_item)
                 assigned_ids.add(other_fid)
 


### PR DESCRIPTION
## 变更说明
- 修复外挂字幕关联仍然只依赖完整视频基名前缀的问题
- 将字幕/视频弱关联收口为：同目录下优先按 `season/episode/part` 匹配，必要时再回退完整前缀匹配
- 修复手动重组链路里关联字幕查找过于严格，导致同集但技术标签不完全一致的字幕可能漏绑
- 补充回归测试，覆盖“非完整前缀但同集字幕仍应视为关联 sidecar”的场景

## 背景
- 上一个 PR `#65` 已经 merge，但 merge 后又发现残余风险：
  - 某些链路里字幕和视频仍然靠 `startswith(video_base)` 关联
  - 这会让同集但命名风格不同的外挂字幕漏掉跟随重命名
- 本次 PR 是基于最新 `upstream/dev` 的 follow-up 修补，不继续在已 merge 的 PR 分支上追加

## 验证
- `python -m py_compile handler/p115_service.py handler/p115_media_recognition.py tasks/p115.py`
- `python -m unittest handler.p115_media_recognition`
- `git diff --check -- handler/p115_service.py handler/p115_media_recognition.py tasks/p115.py`
