### PR TITLE
修复 115 整理目录名未清洗导致 fs_mkdir 失败

### DIFF
--- a/handler/p115_service.py
+++ b/handler/p115_service.py
@@ -2896,6 +2896,8 @@ def get_config():
     return config_manager.APP_CONFIG
 
 class SmartOrganizer(P115MediaAnalyzerMixin):
+    _P115_INVALID_NAME_CHARS_RE = re.compile(r'[\\/:*?"<>|]')
+
     def __init__(self, client, tmdb_id, media_type, original_title, ai_translator=None, use_ai=False):
         self.client = client
         self.tmdb_id = tmdb_id
@@ -3448,10 +3450,16 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
             val = None
             is_sep = False
             
-            # 优先使用传入的 safe_title，防止文件名包含 \/:*?"<>| 导致报错
-            if block == 'title_zh': val = safe_title if safe_title else (self.details.get('title') or self.original_title)
-            elif block == 'title_en': val = self.details.get('title_en') or original_title or self.details.get('original_title') or self.original_title
-            elif block == 'title_orig': val = original_title or self.details.get('original_title') or self.original_title
+            # 标题块统一做 115 非法字符清洗，避免目录/文件名因原文标题中的引号等字符创建失败。
+            if block == 'title_zh':
+                raw_title = safe_title if safe_title else (self.details.get('title') or self.original_title)
+                val = self._sanitize_115_name_component(raw_title)
+            elif block == 'title_en':
+                raw_title = self.details.get('title_en') or original_title or self.details.get('original_title') or self.original_title
+                val = self._sanitize_115_name_component(raw_title)
+            elif block == 'title_orig':
+                raw_title = original_title or self.details.get('original_title') or self.original_title
+                val = self._sanitize_115_name_component(raw_title)
             elif block == 'year': val = f"({self.details.get('date', '')[:4]})" if self.details.get('date') else None
             elif block == 'year_pure': val = self.details.get('date', '')[:4] if self.details.get('date') else None
             elif block == 'tmdb_bracket': val = f"{{tmdb={self.tmdb_id}}}"
@@ -3507,6 +3515,12 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                 final_parts.append(item['val'])
 
         return "".join(final_parts)
+
+    @classmethod
+    def _sanitize_115_name_component(cls, text):
+        cleaned = utils.clean_invisible_chars(text)
+        cleaned = cls._P115_INVALID_NAME_CHARS_RE.sub('', cleaned).strip()
+        return cleaned
 
     def _get_episode_regex_rules(self):
         """懒加载自定义季集号识别规则，避免每个文件都查数据库"""
@@ -4411,7 +4425,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
         
         # ★ 必须保留 safe_title 的计算，供后续文件重命名使用
         base_title = original_title if cfg.get('main_title_lang', 'zh') == 'original' else title
-        safe_title = re.sub(r'[\\/:*?"<>|]', '', base_title).strip()
+        safe_title = self._sanitize_115_name_component(base_title)
 
         # ★ 保留原名只影响文件名，不影响主目录
         # batch 模式 root_name 可能是“批量文件”，绝不能拿它当目标主目录
@@ -4419,7 +4433,8 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
         std_root_name = self._build_name_from_format(
             main_format,
             is_tv=(self.media_type == 'tv'),
-            original_title=original_title
+            original_title=original_title,
+            safe_title=safe_title
         )
 
         # 兜底防空

--- a/tests/test_p115_name_sanitize.py
+++ b/tests/test_p115_name_sanitize.py
@@ -1,0 +1,139 @@
+import sys
+import types
+import unittest
+
+
+class _DummyCursor:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, *args, **kwargs):
+        return None
+
+    def fetchone(self):
+        return None
+
+
+class _DummyConnection:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return _DummyCursor()
+
+
+def _install_test_stubs():
+    gevent_mod = sys.modules.get("gevent") or types.ModuleType("gevent")
+    gevent_mod.spawn_later = lambda *args, **kwargs: None
+    sys.modules["gevent"] = gevent_mod
+
+    config_manager_mod = sys.modules.get("config_manager") or types.ModuleType("config_manager")
+    config_manager_mod.APP_CONFIG = {"tmdb_api_key": "dummy"}
+    sys.modules["config_manager"] = config_manager_mod
+
+    constants_mod = sys.modules.get("constants") or types.ModuleType("constants")
+    constants_mod.CONFIG_OPTION_TMDB_API_KEY = "tmdb_api_key"
+    sys.modules["constants"] = constants_mod
+
+    settings_db_mod = sys.modules.get("database.settings_db") or types.ModuleType("database.settings_db")
+    settings_db_mod.get_setting = lambda key: {}
+    settings_db_mod.save_setting = lambda key, value: None
+    sys.modules["database.settings_db"] = settings_db_mod
+
+    database_pkg = sys.modules.get("database") or types.ModuleType("database")
+    database_pkg.settings_db = settings_db_mod
+    sys.modules["database"] = database_pkg
+
+    conn_mod = sys.modules.get("database.connection") or types.ModuleType("database.connection")
+    conn_mod.get_db_connection = lambda: _DummyConnection()
+    sys.modules["database.connection"] = conn_mod
+
+    tmdb_mod = sys.modules.get("handler.tmdb") or types.ModuleType("handler.tmdb")
+    tmdb_mod.get_movie_details = lambda *args, **kwargs: {
+        "title": 'Falco - Forever Number One: 40 Jahre "Rock Me Amadeus"',
+        "original_title": 'Falco - Forever Number One: 40 Jahre "Rock Me Amadeus"',
+        "alternative_titles": {"titles": [], "results": []},
+        "release_date": "2026-01-01",
+        "genres": [],
+        "production_countries": [],
+        "production_companies": [],
+        "credits": {"cast": []},
+        "keywords": {"keywords": []},
+    }
+    tmdb_mod.get_tv_details = lambda *args, **kwargs: {}
+    sys.modules["handler.tmdb"] = tmdb_mod
+
+    helpers_mod = sys.modules.get("tasks.helpers") or types.ModuleType("tasks.helpers")
+    helpers_mod.RELEASE_GROUPS = {}
+    sys.modules["tasks.helpers"] = helpers_mod
+
+    tasks_pkg = sys.modules.get("tasks") or types.ModuleType("tasks")
+    tasks_pkg.helpers = helpers_mod
+    sys.modules["tasks"] = tasks_pkg
+
+    tg_candidate_mod = sys.modules.get("handler.tg_media_candidate") or types.ModuleType("handler.tg_media_candidate")
+    tg_candidate_mod.candidate_to_recognition_hints = lambda *args, **kwargs: {}
+    tg_candidate_mod.is_recognition_hint_eligible = lambda *args, **kwargs: False
+    tg_candidate_mod.lookup_candidate_hint_for_name = lambda *args, **kwargs: {}
+    sys.modules["handler.tg_media_candidate"] = tg_candidate_mod
+
+    p115client_mod = sys.modules.get("p115client") or types.ModuleType("p115client")
+    p115client_mod.P115Client = object
+    sys.modules["p115client"] = p115client_mod
+
+
+_install_test_stubs()
+
+from handler.p115_service import SmartOrganizer
+
+
+class P115NameSanitizeTests(unittest.TestCase):
+    def _build_organizer(self):
+        organizer = SmartOrganizer(
+            client=object(),
+            tmdb_id="1654963",
+            media_type="movie",
+            original_title='Falco - Forever Number One: 40 Jahre "Rock Me Amadeus"',
+        )
+        organizer.details = {
+            "title": 'Falco - Forever Number One: 40 Jahre "Rock Me Amadeus"',
+            "title_en": 'Falco - Forever Number One: 40 Jahre "Rock Me Amadeus"',
+            "original_title": 'Falco - Forever Number One: 40 Jahre "Rock Me Amadeus"',
+            "date": "2026-01-01",
+        }
+        return organizer
+
+    def test_title_en_and_title_orig_are_sanitized(self):
+        organizer = self._build_organizer()
+
+        title_en = organizer._build_name_from_format(["title_en"])
+        title_orig = organizer._build_name_from_format(["title_orig"])
+
+        self.assertEqual(title_en, "Falco - Forever Number One 40 Jahre Rock Me Amadeus")
+        self.assertEqual(title_orig, "Falco - Forever Number One 40 Jahre Rock Me Amadeus")
+        self.assertNotIn('"', title_en)
+        self.assertNotIn(":", title_en)
+
+    def test_main_dir_format_uses_safe_title_for_title_zh(self):
+        organizer = self._build_organizer()
+
+        result = organizer._build_name_from_format(
+            ["title_zh", "sep_space", "year", "sep_space", "tmdb_bracket"],
+            original_title=organizer.details["original_title"],
+            safe_title='Falco - Forever Number One 40 Jahre Rock Me Amadeus',
+        )
+
+        self.assertEqual(
+            result,
+            "Falco - Forever Number One 40 Jahre Rock Me Amadeus (2026) {tmdb=1654963}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明
- 修复 115 整理时主目录名未统一清洗非法字符的问题。
- 对 `title_zh`、`title_en`、`title_orig` 三类标题块统一做 115 非法字符过滤，避免原始标题中的 `\\ / : * ? \" < > |` 导致 `fs_mkdir` 创建目录失败。
- 主目录生成时显式传入 `safe_title`，避免仅文件名走清洗、目录名仍保留非法字符。
- 新增回归测试，覆盖英文原名包含双引号和冒号时的目录名生成结果。

## 问题背景
Unraid live 容器在 `2026-06-04 08:56:10` 整理以下资源时失败：

`Falco - Forever Number One: 40 Jahre "Rock Me Amadeus" (2026) {tmdb=1654963}`

日志显示两套 mkdir 接口都拒绝了目录名中的双引号：
- `cookie 接口 fs_mkdir 返回失败: 文件名不能包含以下任意字符之一""<>"`
- `openapi 接口 fs_mkdir 返回失败: 文件名不能包含以下任意字符之一 “ " < > ”`
- 随后报错 `无法获取或创建目标目录链 (已尝试所有手段)`

## 验证
- `python -m py_compile handler/p115_service.py tests/test_p115_name_sanitize.py`
- `python -m unittest tests.test_p115_name_sanitize`
- `git diff --check`
- `git etk-pr-check`
- `bash .git-tools/etk-local-sandbox-up.sh`
  - 当前分支镜像 `etk-sandbox:codex-p115-dirname-sanitize` 构建成功
  - 本地 sandbox 容器健康启动

## 备注
- 本次未对 Unraid live 容器执行真实 115 整理写操作，只使用了 live 日志做只读证据采样。
