### PR TITLE
修复大包逐文件整理丢失顶层 TMDb 上下文

### DIFF
--- a/handler/p115_media_recognition.py
+++ b/handler/p115_media_recognition.py
@@ -559,6 +559,124 @@ class P115RecognitionRuleTests(unittest.TestCase):
         self.assertNotIn("season_number", hints)
         self.assertNotIn("episode_number", hints)
 
+    def test_filewise_big_package_prefers_top_level_explicit_tmdbid_over_file_search(self):
+        gathered_files = [
+            {
+                "fid": "v1",
+                "file_id": "v1",
+                "fn": "Neymar.The.Perfect.Chaos.S01E01.2022.2160p.NF.WEB-DL.mkv",
+                "sha1": "sha-v1",
+                "fs": str(7 * 1024 * 1024 * 1024),
+                "_etk_rel_dir": "Neymar.The.Perfect.Chaos.S01",
+            }
+        ]
+
+        def fake_identify(filename, main_dir_name=None, **kwargs):
+            self.assertEqual(main_dir_name, "内马尔：完美乱局 (2022) {tmdbid-153519}")
+            return "153519", "tv", "Neymar: The Perfect Chaos"
+
+        with mock.patch.object(task_p115, "_identify_media_enhanced", side_effect=fake_identify):
+            groups, unresolved = task_p115._build_filewise_big_package_groups(
+                gathered_files,
+                "内马尔：完美乱局 (2022) {tmdbid-153519}",
+                use_ai=False,
+            )
+
+        self.assertEqual(unresolved, [])
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["identified_tmdb_id"], "153519")
+        self.assertEqual(groups[0]["identified_title"], "Neymar: The Perfect Chaos")
+
+    def test_filewise_big_package_keeps_distinct_nested_contexts_separate(self):
+        gathered_files = [
+            {
+                "fid": "v1",
+                "file_id": "v1",
+                "fn": "Show.A.S01E01.2022.1080p.WEB-DL.mkv",
+                "sha1": "sha-a1",
+                "fs": str(7 * 1024 * 1024 * 1024),
+                "_etk_rel_dir": "Show A (2022) {tmdbid-111111}/Season 01",
+            },
+            {
+                "fid": "v2",
+                "file_id": "v2",
+                "fn": "Show.B.S01E01.2023.1080p.WEB-DL.mkv",
+                "sha1": "sha-b1",
+                "fs": str(7 * 1024 * 1024 * 1024),
+                "_etk_rel_dir": "Show B (2023) {tmdbid-222222}/Season 01",
+            },
+        ]
+
+        seen_main_dirs = []
+
+        def fake_identify(filename, main_dir_name=None, **kwargs):
+            seen_main_dirs.append(main_dir_name)
+            if "Show.A" in filename:
+                return "111111", "tv", "Show A"
+            return "222222", "tv", "Show B"
+
+        with mock.patch.object(task_p115, "_identify_media_enhanced", side_effect=fake_identify):
+            groups, unresolved = task_p115._build_filewise_big_package_groups(
+                gathered_files,
+                "Mixed Resource Pack",
+                use_ai=False,
+            )
+
+        self.assertEqual(unresolved, [])
+        self.assertEqual(len(groups), 2)
+        self.assertIn("Show A (2022) {tmdbid-111111}", seen_main_dirs)
+        self.assertIn("Show B (2023) {tmdbid-222222}", seen_main_dirs)
+        self.assertEqual({g["identified_tmdb_id"] for g in groups}, {"111111", "222222"})
+
+    def test_filewise_big_package_without_explicit_tmdbid_keeps_context_search(self):
+        gathered_files = [
+            {
+                "fid": "v1",
+                "file_id": "v1",
+                "fn": "Plain.Show.S01E01.2022.1080p.WEB-DL.mkv",
+                "sha1": "sha-v1",
+                "fs": str(7 * 1024 * 1024 * 1024),
+                "_etk_rel_dir": "Plain Show (2022)/Season 01",
+            }
+        ]
+
+        def fake_identify(filename, main_dir_name=None, **kwargs):
+            self.assertEqual(main_dir_name, "Plain Show (2022)")
+            return "333333", "tv", "Plain Show"
+
+        with mock.patch.object(task_p115, "_identify_media_enhanced", side_effect=fake_identify):
+            groups, unresolved = task_p115._build_filewise_big_package_groups(
+                gathered_files,
+                "Generic Pack",
+                use_ai=False,
+            )
+
+        self.assertEqual(unresolved, [])
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0]["identified_tmdb_id"], "333333")
+
+    def test_identify_media_enhanced_prefers_main_dir_explicit_tmdbid_for_normal_path(self):
+        with mock.patch.object(
+            p115_service.tmdb,
+            "get_tv_details",
+            return_value={"name": "Neymar: The Perfect Chaos"},
+        ) as details_mock:
+            with mock.patch.dict(
+                p115_service.config_manager.APP_CONFIG,
+                {"tmdb_api_key": "fake"},
+                clear=False,
+            ):
+                tmdb_id, media_type, title = p115_service._identify_media_enhanced(
+                    "Neymar.The.Perfect.Chaos.S01E01.2022.2160p.NF.WEB-DL.mkv",
+                    main_dir_name="内马尔：完美乱局 (2022) {tmdbid-153519}",
+                    use_ai=False,
+                )
+
+        self.assertEqual(tmdb_id, "153519")
+        self.assertEqual(media_type, "tv")
+        self.assertEqual(title, "Neymar: The Perfect Chaos")
+        details_mock.assert_called_once_with("153519", "fake")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tasks/p115.py
+++ b/tasks/p115.py
@@ -275,6 +275,9 @@ def _build_filewise_big_package_groups(gathered_files, top_name, ai_translator=N
         file_name = video_item.get('fn') or video_item.get('n') or video_item.get('file_name', '')
         rel_dir = video_item.get('_etk_rel_dir', '')
         context_name = _choose_big_package_context_name(top_name, rel_dir)
+        identify_main_dir = context_name or top_name
+        if not _name_has_tmdb_tag(identify_main_dir) and _name_has_tmdb_tag(top_name):
+            identify_main_dir = top_name
         forced_type = 'tv' if (_name_has_tv_hint(file_name) or _name_has_tv_hint(rel_dir)) else None
         season_num = _extract_season_number(file_name, rel_dir, context_name)
         recognition_hints = _normalize_batch_recognition_hints(lookup_candidate_hint_for_name(
@@ -286,7 +289,7 @@ def _build_filewise_big_package_groups(gathered_files, top_name, ai_translator=N
         file_sha1 = video_item.get('sha1') or video_item.get('sha')
         tmdb_id, media_type, title = _identify_media_enhanced(
             file_name,
-            main_dir_name=context_name,
+            main_dir_name=identify_main_dir,
             has_season_subdirs=False,
             forced_media_type=forced_type,
             ai_translator=ai_translator,


### PR DESCRIPTION
## 摘要
- 修复大包逐文件整理时丢失顶层 `tmdb/tmdbid` 显式上下文的问题
- 为嵌套大包路由、无显式 ID 回退识别、普通显式 TMDb 链路补充回归覆盖
- 保持普通非大包识别路径不变，同时避免错误退化到模糊搜索

## 验证
- `python -m py_compile tasks/p115.py handler/p115_media_recognition.py`
- `python -m unittest handler.p115_media_recognition`
- `git diff --check -- tasks/p115.py handler/p115_media_recognition.py`
