### PR TITLE
修复自动更新后 TG 结果补发与 Web 页面恢复刷新

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -4,6 +4,7 @@ import configparser
 import logging
 from typing import Dict, Any, Tuple, Optional
 import json
+import time
 from database import settings_db
 # --- 核心模块导入 ---
 import constants # 你的常量定义
@@ -14,21 +15,23 @@ logger = logging.getLogger(__name__)
 
 def _notify_pending_system_update_result():
     try:
-        from tasks.system_update import consume_post_update_status
-        payload = consume_post_update_status()
+        from tasks.system_update import peek_post_update_status, clear_post_update_status
+        payload = peek_post_update_status()
     except Exception as e:
         logger.debug(f"读取待通知的系统更新结果失败: {e}")
-        return
+        return False
 
     if not payload:
-        return
+        return False
+
+    logger.info("  ➜ 检测到待补发的系统更新结果，准备发送通知。")
 
     try:
         from database import user_db
         from handler.telegram import send_telegram_message, escape_markdown
     except Exception as e:
         logger.warning(f"系统更新结果通知依赖未就绪，跳过发送: {e}")
-        return
+        return False
 
     current_version = str(payload.get("current_version") or "").strip()
     target_version = str(payload.get("target_version") or "").strip()
@@ -52,10 +55,33 @@ def _notify_pending_system_update_result():
 
     text = escape_markdown("\n".join(lines))
     try:
-        for chat_id in set(user_db.get_admin_telegram_chat_ids() or []):
+        admin_chat_ids = set(user_db.get_admin_telegram_chat_ids() or [])
+        if not admin_chat_ids:
+            logger.warning("系统更新结果通知未发送：当前没有可用的管理员 Telegram Chat ID。")
+            return False
+
+        for chat_id in admin_chat_ids:
             send_telegram_message(str(chat_id), text)
     except Exception as e:
         logger.warning(f"发送系统更新结果 TG 通知失败: {e}")
+        return False
+
+    if clear_post_update_status():
+        logger.info("  ➜ 系统更新结果通知发送成功，已清理待通知结果文件。")
+    else:
+        logger.warning("系统更新结果通知已发送，但清理结果文件失败。")
+    return True
+
+
+def retry_pending_system_update_result(max_attempts: int = 10, interval_seconds: float = 3.0):
+    """在启动后的短窗口内重试补发系统更新结果，避免依赖初始化时机导致漏发。"""
+    for attempt in range(1, max_attempts + 1):
+        if _notify_pending_system_update_result():
+            return True
+        if attempt < max_attempts:
+            time.sleep(interval_seconds)
+    logger.warning("系统更新结果通知重试结束，仍未成功发送。")
+    return False
 
 # --- 路径和配置定义 ---
 # 这部分逻辑与配置紧密相关，所以移到这里

--- a/emby-actor-ui/src/AppContent.vue
+++ b/emby-actor-ui/src/AppContent.vue
@@ -69,6 +69,8 @@ const isOpeningEditor = ref(false);
 
 const backgroundTaskStatus = ref({ is_running: false, current_action: '空闲' });
 let statusIntervalId = null;
+const pendingSystemUpdateReload = ref(false);
+const waitingForBackendRecovery = ref(false);
 
 const app = document.getElementById('app');
 
@@ -219,13 +221,29 @@ watch(() => authStore.isLoggedIn, (isLoggedIn) => {
         try {
           const response = await axios.get('/api/status');
           backgroundTaskStatus.value = response.data;
+          if (waitingForBackendRecovery.value) {
+            waitingForBackendRecovery.value = false;
+            if (pendingSystemUpdateReload.value) {
+              window.location.reload();
+              return;
+            }
+          }
+          const statusMessage = String(response.data?.message || '');
+          if (statusMessage.includes('系统正在重启')) {
+            pendingSystemUpdateReload.value = true;
+          }
         } catch (error) { console.error('获取状态失败:', error); }
+        if (pendingSystemUpdateReload.value) {
+          waitingForBackendRecovery.value = true;
+        }
       };
       fetchStatus();
       statusIntervalId = setInterval(fetchStatus, 2000);
     }
   } else {
     if (statusIntervalId) { clearInterval(statusIntervalId); statusIntervalId = null; }
+    pendingSystemUpdateReload.value = false;
+    waitingForBackendRecovery.value = false;
   }
 }, { immediate: true });
 

--- a/handler/telegram.py
+++ b/handler/telegram.py
@@ -2382,6 +2382,17 @@ def start_telegram_bot():
     _tg_polling_thread = threading.Thread(target=_telegram_polling_worker, daemon=True, name="TG_Polling_Thread")
     _tg_polling_thread.start()
 
+    try:
+        from config_manager import retry_pending_system_update_result
+        threading.Thread(
+            target=retry_pending_system_update_result,
+            kwargs={"max_attempts": 10, "interval_seconds": 3.0},
+            daemon=True,
+            name="SystemUpdateNotifyRetry",
+        ).start()
+    except Exception as e:
+        logger.debug(f"  ➜ 启动系统更新结果通知重试线程失败: {e}")
+
 def stop_telegram_bot():
     """停止 Telegram 机器人监听"""
     global _tg_polling_active

--- a/tasks/system_update.py
+++ b/tasks/system_update.py
@@ -347,6 +347,22 @@ def consume_post_update_status():
     return payload
 
 
+def peek_post_update_status():
+    return _read_json_file(_get_update_status_path())
+
+
+def clear_post_update_status():
+    status_path = _get_update_status_path()
+    try:
+        os.remove(status_path)
+    except FileNotFoundError:
+        return False
+    except Exception as e:
+        logger.warning(f"删除更新状态文件失败: {status_path}, err={e}")
+        return False
+    return True
+
+
 def _normalize_container_path(path_value):
     path_text = _clean_version_text(path_value)
     if not path_text:

--- a/tests/test_system_update_post_notify.py
+++ b/tests/test_system_update_post_notify.py
@@ -165,6 +165,8 @@ def _install_stubs():
 
     tasks_system_update = sys.modules.get("tasks.system_update") or types.ModuleType("tasks.system_update")
     tasks_system_update.consume_post_update_status = lambda: None
+    tasks_system_update.peek_post_update_status = lambda: None
+    tasks_system_update.clear_post_update_status = lambda: True
     sys.modules["tasks.system_update"] = tasks_system_update
 
 
@@ -181,16 +183,52 @@ class PostUpdateNotifyTests(unittest.TestCase):
             "target_version": "v10.2.6",
             "message": "容器健康检查通过。",
         }
-        with mock.patch("tasks.system_update.consume_post_update_status", return_value=payload):
-            with mock.patch("handler.telegram.send_telegram_message") as send_mock:
-                config_manager._notify_pending_system_update_result()
+        with mock.patch("tasks.system_update.peek_post_update_status", return_value=payload):
+            with mock.patch("tasks.system_update.clear_post_update_status", return_value=True) as clear_mock:
+                with mock.patch("handler.telegram.send_telegram_message") as send_mock:
+                    result = config_manager._notify_pending_system_update_result()
 
+        self.assertTrue(result)
         send_mock.assert_called_once()
+        clear_mock.assert_called_once()
         message = send_mock.call_args.args[1]
         self.assertIn("系统自动更新", message)
         self.assertIn("10.2.5", message)
         self.assertIn("v10.2.6", message)
         self.assertIn("容器健康检查通过。", message)
+
+    def test_notify_pending_system_update_result_keeps_file_when_send_fails(self):
+        payload = {
+            "ok": True,
+            "current_version": "10.2.5",
+            "target_version": "v10.2.6",
+            "message": "容器健康检查通过。",
+        }
+        with mock.patch("tasks.system_update.peek_post_update_status", return_value=payload):
+            with mock.patch("tasks.system_update.clear_post_update_status", return_value=True) as clear_mock:
+                with mock.patch("handler.telegram.send_telegram_message", side_effect=RuntimeError("tg down")):
+                    result = config_manager._notify_pending_system_update_result()
+
+        self.assertFalse(result)
+        clear_mock.assert_not_called()
+
+    def test_retry_pending_system_update_result_retries_until_success(self):
+        with mock.patch.object(config_manager, "_notify_pending_system_update_result", side_effect=[False, False, True]) as notify_mock:
+            with mock.patch("time.sleep") as sleep_mock:
+                result = config_manager.retry_pending_system_update_result(max_attempts=5, interval_seconds=1.5)
+
+        self.assertTrue(result)
+        self.assertEqual(notify_mock.call_count, 3)
+        self.assertEqual(sleep_mock.call_count, 2)
+
+    def test_retry_pending_system_update_result_returns_false_after_exhausted_attempts(self):
+        with mock.patch.object(config_manager, "_notify_pending_system_update_result", return_value=False) as notify_mock:
+            with mock.patch("time.sleep") as sleep_mock:
+                result = config_manager.retry_pending_system_update_result(max_attempts=3, interval_seconds=1.5)
+
+        self.assertFalse(result)
+        self.assertEqual(notify_mock.call_count, 3)
+        self.assertEqual(sleep_mock.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
问题背景

在 live 容器完成自动更新后，实际观察到两个问题：

1. 更新成功后，没有再次通过 Telegram 补发最终更新结果。
2. Web 页面在容器重启后不会自动恢复，需要用户手动刷新。

问题分析

1. TG 补发结果未发送
- live 容器上的 `/config/system_update_result.json` 仍然残留，说明新容器启动后并没有成功消费这份更新结果。
- 原有逻辑在配置加载早期就尝试读取并消费更新结果，时机过早；如果此时 Telegram 依赖、管理员列表或相关能力尚未完全就绪，就容易漏发。
- 且原逻辑一旦消费结果文件，就没有后续可靠重试机制。

2. Web 页面不会自动恢复
- 前端目前只是周期性轮询 `/api/status`。
- 当容器因系统自动更新而重启时，浏览器端请求会短暂失败，但没有“后端恢复后自动刷新页面”的逻辑。
- 因此用户通常需要手动刷新当前页面才能恢复正常交互。

本次修复

1. 提升系统更新结果补发可靠性
- 为更新结果文件新增 `peek` / `clear` 语义，避免在发送失败时过早删除结果文件。
- 配置加载阶段检测到待补发结果时，不再默认直接消费并删除；只有在通知发送成功后才清理结果文件。
- 当 Telegram 依赖尚未就绪、管理员列表为空、或发送异常时，保留结果文件，等待后续重试。
- 在 Telegram 机器人真正启动后，增加短时重试线程，补发系统更新最终结果。
- 增加启动期日志，便于后续排查“是否检测到结果文件”和“是否成功清理”。

2. 提升 Web 页面在系统更新重启后的恢复体验
- 当前端检测到任务状态进入“系统正在重启”时，标记本次轮询属于系统更新重启场景。
- 如果此后 `/api/status` 轮询失败，则进入“等待后端恢复”状态。
- 一旦后端恢复、状态接口再次可访问，前端自动刷新当前页面，减少用户手动刷新成本。

测试与验证

后端验证：
```bash
python -m py_compile tasks/system_update.py config_manager.py handler/telegram.py tests/test_telegram_system_update_notification.py tests/test_system_update_post_notify.py
python -m unittest tests.test_telegram_system_update_notification tests.test_system_update_post_notify
git diff --check
git etk-pr-check
```

前端验证：
```bash
cd emby-actor-ui
npm run build
```

新增/调整测试覆盖：
- 更新结果通知发送成功后清理结果文件
- 更新结果通知发送失败时保留结果文件
- 启动后补发重试会在成功时停止
- 启动后补发重试在用尽次数后返回失败

影响范围

本次修改仅影响：
- 系统自动更新完成后的 TG 结果补发链路
- 系统自动更新导致容器重启后的前端恢复体验

不涉及普通业务任务处理逻辑变更。
