### PR TITLE
修复 Docker Helper 自动更新的网络重建兼容性

### DIFF
--- a/tasks/system_update.py
+++ b/tasks/system_update.py
@@ -116,22 +116,29 @@ def build_networking(client, container_attrs):
     network_mode = host_config.get("NetworkMode") or "default"
     network_settings = (container_attrs.get("NetworkSettings") or {}).get("Networks") or {}
     networking_config = None
+    endpoint_network_mode = (network_mode or "").split(":", 1)[0]
 
-    if network_mode not in {"host", "none", "container"} and network_settings:
+    if endpoint_network_mode not in {"host", "none", "container"} and network_settings:
         endpoints = {}
         for network_name, network_data in network_settings.items():
             endpoint_kwargs = {}
             aliases = list(network_data.get("Aliases") or [])
             if aliases:
                 endpoint_kwargs["aliases"] = aliases
-            ipv4_address = (network_data.get("IPAMConfig") or {}).get("IPv4Address") or network_data.get("IPAddress")
+            is_user_defined = bool(network_data.get("NetworkID")) and network_name not in {"bridge", "host", "none"}
+            ipv4_address = (network_data.get("IPAMConfig") or {}).get("IPv4Address")
+            if not ipv4_address and is_user_defined:
+                ipv4_address = network_data.get("IPAddress")
             if ipv4_address:
                 endpoint_kwargs["ipv4_address"] = ipv4_address
-            ipv6_address = (network_data.get("IPAMConfig") or {}).get("IPv6Address") or network_data.get("GlobalIPv6Address")
+            ipv6_address = (network_data.get("IPAMConfig") or {}).get("IPv6Address")
+            if not ipv6_address and is_user_defined:
+                ipv6_address = network_data.get("GlobalIPv6Address")
             if ipv6_address:
                 endpoint_kwargs["ipv6_address"] = ipv6_address
             endpoints[network_name] = client.api.create_endpoint_config(**endpoint_kwargs)
-        networking_config = client.api.create_networking_config(endpoints)
+        if endpoints:
+            networking_config = client.api.create_networking_config(endpoints)
 
     return network_mode, networking_config
 
@@ -147,6 +154,10 @@ def collect_create_kwargs(client, container):
     port_bindings = build_port_bindings(host_config)
     restart_policy = build_restart_policy(host_config)
     network_mode, networking_config = build_networking(client, attrs)
+    network_mode_kind = (network_mode or "").split(":", 1)[0]
+    if network_mode_kind in {"host", "container"}:
+        port_bindings = None
+        ports = None
     healthcheck = config.get("Healthcheck")
     host_cfg = client.api.create_host_config(
         auto_remove=bool(host_config.get("AutoRemove")),

--- a/tests/test_telegram_system_update_notification.py
+++ b/tests/test_telegram_system_update_notification.py
@@ -87,7 +87,131 @@ telegram = importlib.import_module("handler.telegram")
 system_update = importlib.import_module("tasks.system_update")
 
 
+def _load_helper_namespace():
+    helper_env = {
+        "ETK_UPDATE_STATUS_PATH": "/config/system_update_result.json",
+        "ETK_TARGET_CONTAINER": "emby-toolkit",
+        "ETK_TARGET_IMAGE": "hbq0405/emby-toolkit:latest",
+    }
+    namespace = {}
+    with mock.patch.dict("os.environ", helper_env, clear=False):
+        exec(system_update.DOCKER_HELPER_SCRIPT, namespace)
+    return namespace
+
+
 class TelegramSystemUpdateNotificationTests(unittest.TestCase):
+    def test_collect_create_kwargs_skips_port_bindings_for_host_network(self):
+        helper = _load_helper_namespace()
+        fake_client = mock.Mock()
+        fake_client.api.create_host_config.return_value = {"kind": "host-config"}
+
+        fake_container = mock.Mock()
+        fake_container.name = "emby-toolkit"
+        fake_container.attrs = {
+            "Config": {
+                "ExposedPorts": {"8096/tcp": {}},
+                "Env": ["A=B"],
+            },
+            "HostConfig": {
+                "NetworkMode": "host",
+                "PortBindings": {
+                    "8096/tcp": [{"HostIp": "", "HostPort": "8096"}]
+                },
+            },
+            "NetworkSettings": {
+                "Networks": {}
+            },
+        }
+
+        kwargs = helper["collect_create_kwargs"](fake_client, fake_container)
+
+        self.assertIsNone(kwargs["ports"])
+        host_config_kwargs = fake_client.api.create_host_config.call_args.kwargs
+        self.assertEqual(host_config_kwargs["network_mode"], "host")
+        self.assertIsNone(host_config_kwargs["port_bindings"])
+
+    def test_collect_create_kwargs_skips_runtime_ip_for_default_bridge(self):
+        helper = _load_helper_namespace()
+        fake_client = mock.Mock()
+        fake_client.api.create_host_config.return_value = {"kind": "host-config"}
+
+        endpoint_calls = []
+
+        def fake_endpoint_config(**kwargs):
+            endpoint_calls.append(kwargs)
+            return {"endpoint": kwargs}
+
+        fake_client.api.create_endpoint_config.side_effect = fake_endpoint_config
+        fake_client.api.create_networking_config.side_effect = lambda endpoints: {"endpoints": endpoints}
+
+        fake_container = mock.Mock()
+        fake_container.name = "emby-toolkit"
+        fake_container.attrs = {
+            "Config": {
+                "Env": ["A=B"],
+            },
+            "HostConfig": {
+                "NetworkMode": "bridge",
+            },
+            "NetworkSettings": {
+                "Networks": {
+                    "bridge": {
+                        "Aliases": ["emby-toolkit"],
+                        "IPAddress": "172.17.0.2",
+                        "GlobalIPv6Address": "",
+                        "IPAMConfig": None,
+                        "NetworkID": "bridge-id",
+                    }
+                }
+            },
+        }
+
+        kwargs = helper["collect_create_kwargs"](fake_client, fake_container)
+
+        self.assertEqual(endpoint_calls, [{"aliases": ["emby-toolkit"]}])
+        self.assertEqual(kwargs["networking_config"], {"endpoints": {"bridge": {"endpoint": {"aliases": ["emby-toolkit"]}}}})
+
+    def test_collect_create_kwargs_keeps_explicit_static_ip_for_user_defined_network(self):
+        helper = _load_helper_namespace()
+        fake_client = mock.Mock()
+        fake_client.api.create_host_config.return_value = {"kind": "host-config"}
+
+        endpoint_calls = []
+
+        def fake_endpoint_config(**kwargs):
+            endpoint_calls.append(kwargs)
+            return {"endpoint": kwargs}
+
+        fake_client.api.create_endpoint_config.side_effect = fake_endpoint_config
+        fake_client.api.create_networking_config.side_effect = lambda endpoints: {"endpoints": endpoints}
+
+        fake_container = mock.Mock()
+        fake_container.name = "emby-toolkit"
+        fake_container.attrs = {
+            "Config": {
+                "Env": ["A=B"],
+            },
+            "HostConfig": {
+                "NetworkMode": "custom-net",
+            },
+            "NetworkSettings": {
+                "Networks": {
+                    "custom-net": {
+                        "Aliases": ["emby-toolkit"],
+                        "IPAddress": "172.20.0.5",
+                        "GlobalIPv6Address": "",
+                        "IPAMConfig": {"IPv4Address": "172.20.0.5"},
+                        "NetworkID": "custom-net-id",
+                    }
+                }
+            },
+        }
+
+        kwargs = helper["collect_create_kwargs"](fake_client, fake_container)
+
+        self.assertEqual(endpoint_calls, [{"aliases": ["emby-toolkit"], "ipv4_address": "172.20.0.5"}])
+        self.assertEqual(kwargs["networking_config"], {"endpoints": {"custom-net": {"endpoint": {"aliases": ["emby-toolkit"], "ipv4_address": "172.20.0.5"}}}})
+
     def test_task_check_and_update_container_falls_back_when_logger_has_no_trace(self):
         fake_processor = types.SimpleNamespace(config={})
         fake_logger = mock.Mock(spec=["debug", "info", "error", "warning"])


### PR DESCRIPTION
问题背景

不同用户在 Docker Helper 自动更新时又暴露出两类新的容器重建失败：

1. `host network_mode is incompatible with port_bindings`
2. `invalid config for network bridge: invalid endpoint settings: user specified IP address is supported on user defined networks only`

这不是之前脚本挂载问题的回归，而是 Docker Helper 在“按原容器配置重建新容器”时遗漏了网络模式兼容分支。

根因分析

当前 helper 会直接复用旧容器的 `PortBindings`、`ExposedPorts` 和 `NetworkSettings.Networks` 信息来重建新容器，但不同网络模式下这些字段并不能无条件共存：

- `host` 或 `container:<id>` 网络模式下，Docker 不允许再传 `port_bindings`
- 默认 `bridge` 网络下，运行时分配到的 `IPAddress` 不能被当作显式静态 IP 回灌到 `networking_config`
- 只有用户自定义网络里显式配置过的 IP，才应该在 endpoint config 中继续保留

因此，不同用户只要容器网络模型不同，就会在 helper 重建阶段直接收到 Docker API 400 错误。

本次修复

1. 按网络模式裁剪端口映射参数
- 当 `NetworkMode` 为 `host` 或 `container:<id>` 时，不再向 Docker API 传 `ports` 和 `port_bindings`
- 避免触发 `host network_mode is incompatible with port_bindings`

2. 只在用户自定义网络中保留显式 IP 配置
- 默认 `bridge` / `host` / `none` 网络不再回灌运行时 `IPAddress`
- 仅当网络为用户自定义网络，且容器 inspect 中存在显式 `IPAMConfig` 或静态 IP 时，才保留 `ipv4_address` / `ipv6_address`
- 避免触发 `user specified IP address is supported on user defined networks only`

3. 保留原有网络别名
- 网络别名仍会随 endpoint config 一起重建，不影响原有容器名解析行为

测试与验证

代码级验证：
```bash
python -m py_compile tasks/system_update.py tests/test_telegram_system_update_notification.py tests/test_system_update_post_notify.py
python -m unittest tests.test_telegram_system_update_notification tests.test_system_update_post_notify
git diff --check
bash /Users/paysen/Coding-local/emby-toolkit/.git-tools/etk-pr-check.sh --base upstream/dev
```

新增回归覆盖：
- `host` 网络模式下不会再传 `port_bindings`
- 默认 `bridge` 网络下不会回灌运行时 IP
- 用户自定义网络下仍会保留显式静态 IP

本地 helper 运行时最小复现：
- 直接执行内联 helper 脚本中的 `collect_create_kwargs()`
- 已确认：
  - `host` 模式输出 `ports=None` 且 `port_bindings=None`
  - `bridge` 模式 endpoint config 仅保留 `aliases`，不再包含运行时 `IPAddress`

影响范围

本次修改仅影响 Docker Helper 自动更新时的新容器重建参数组装逻辑，不影响普通任务流程。
