### PR TITLE
修复 TG 云资源搜索带季号导致命中率下降

### DIFF
--- a/emby-actor-ui/src/components/HDHiveResourceModal.vue
+++ b/emby-actor-ui/src/components/HDHiveResourceModal.vue
@@ -186,10 +186,20 @@ const rawTitle = computed(() => {
   return props.media?.title || props.media?.name || props.media?.series_title || props.media?.parent_title || '';
 });
 
+const stripSeasonSuffix = (value) => {
+  const text = String(value || '').trim();
+  if (!text) return '';
+
+  return text
+    .replace(/\s*(?:第\s*\d+\s*季|S\d{1,3}|Season\s*\d{1,3})\s*$/i, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+};
+
 const mediaTitle = computed(() => {
   if (!props.media) return '';
 
-  let title = rawTitle.value || '未知影视';
+  let title = stripSeasonSuffix(rawTitle.value) || '未知影视';
   const sNum = props.seasonNumber || props.media.season_number;
 
   if (sNum && !title.includes('季')) {
@@ -350,7 +360,7 @@ const fetchResources = async () => {
 
 watch(() => props.show, (newVal) => {
   if (newVal) {
-    searchTitle.value = rawTitle.value || mediaTitle.value;
+    searchTitle.value = stripSeasonSuffix(rawTitle.value) || rawTitle.value || mediaTitle.value;
     sourceFilter.value = 'all';
     fetchResources();
   }

--- a/routes/subscription.py
+++ b/routes/subscription.py
@@ -1,5 +1,6 @@
 # routes/subscription.py
 import logging
+import re
 from flask import Blueprint, jsonify, request
 from extensions import admin_required
 from database import settings_db
@@ -341,19 +342,25 @@ def _normalize_channel_resource(resource):
     return item
 
 
-def _build_cloud_extra_queries(title, year=None, season=None):
+def _strip_season_suffix(text):
+    value = str(text or "").strip()
+    if not value:
+        return ""
+
+    return re.sub(
+        r"\s*(?:第\s*\d+\s*季|S\d{1,3}|Season\s*\d{1,3})\s*$",
+        "",
+        value,
+        flags=re.IGNORECASE,
+    ).strip()
+
+
+def _build_cloud_extra_queries(title, year=None):
     title = str(title or "").strip()
     year = str(year or "").strip()
-    season = str(season or "").strip()
     queries = []
     if title and year:
         queries.append(f"{title} {year}")
-    if title and season:
-        try:
-            s = int(season)
-            queries.extend([f"{title} S{s:02d}", f"{title} 第{s}季"])
-        except Exception:
-            pass
     return queries
 
 
@@ -364,7 +371,7 @@ def get_cloud_resources():
     tmdb_id = request.args.get('tmdb_id')
     raw_media_type = request.args.get('media_type')
     season = request.args.get('season')
-    title = (request.args.get('title') or request.args.get('query') or '').strip()
+    title = _strip_season_suffix(request.args.get('title') or request.args.get('query') or '')
     year = (request.args.get('year') or '').strip()
     media_type = _normalize_hdhive_media_type(raw_media_type)
 
@@ -427,7 +434,7 @@ def get_cloud_resources():
                 tmdb_id=tmdb_id,
                 year=year,
                 limit=channel_limit,
-                extra_queries=_build_cloud_extra_queries(title, year=year, season=season),
+                extra_queries=_build_cloud_extra_queries(title, year=year),
                 timeout=35,
                 include_tmdb_query=False,
                 strict_title_match=True,

--- a/tests/test_cloud_resource_search_queries.py
+++ b/tests/test_cloud_resource_search_queries.py
@@ -1,0 +1,82 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+def _install_test_stubs():
+    flask_mod = sys.modules.get("flask") or types.ModuleType("flask")
+
+    class _Blueprint:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def route(self, *args, **kwargs):
+            def _decorator(func):
+                return func
+
+            return _decorator
+
+    flask_mod.Blueprint = _Blueprint
+    flask_mod.jsonify = lambda *args, **kwargs: {"args": args, "kwargs": kwargs}
+    flask_mod.request = types.SimpleNamespace(args={})
+    sys.modules["flask"] = flask_mod
+
+    config_manager_mod = sys.modules.get("config_manager") or types.ModuleType("config_manager")
+    config_manager_mod.APP_CONFIG = {}
+    sys.modules["config_manager"] = config_manager_mod
+
+    constants_mod = sys.modules.get("constants") or types.ModuleType("constants")
+    sys.modules["constants"] = constants_mod
+
+    hdhive_mod = sys.modules.get("handler.hdhive_client") or types.ModuleType("handler.hdhive_client")
+    hdhive_mod.HDHiveClient = object
+    sys.modules["handler.hdhive_client"] = hdhive_mod
+
+    tg_userbot_mod = sys.modules.get("handler.tg_userbot") or types.ModuleType("handler.tg_userbot")
+    tg_userbot_mod.TGUserBotManager = object
+    tg_userbot_mod.tg_task_queue = object()
+    sys.modules["handler.tg_userbot"] = tg_userbot_mod
+
+    tg_candidate_mod = sys.modules.get("handler.tg_media_candidate") or types.ModuleType("handler.tg_media_candidate")
+    tg_candidate_mod.build_channel_task_payload = lambda *args, **kwargs: {}
+    sys.modules["handler.tg_media_candidate"] = tg_candidate_mod
+
+    tasks_mod = sys.modules.get("tasks.hdhive") or types.ModuleType("tasks.hdhive")
+    tasks_mod.task_download_from_hdhive = lambda *args, **kwargs: None
+    tasks_mod.filter_hdhive_resources = lambda *args, **kwargs: []
+    sys.modules["tasks.hdhive"] = tasks_mod
+
+    database_pkg = sys.modules.get("database") or types.ModuleType("database")
+    database_pkg.settings_db = types.SimpleNamespace(get_setting=lambda *args, **kwargs: {})
+    sys.modules["database"] = database_pkg
+
+    extensions_mod = sys.modules.get("extensions") or types.ModuleType("extensions")
+    extensions_mod.admin_required = lambda func: func
+    sys.modules["extensions"] = extensions_mod
+
+
+_install_test_stubs()
+subscription = importlib.import_module("routes.subscription")
+
+
+class CloudResourceSearchQueryTests(unittest.TestCase):
+    def test_extra_queries_do_not_include_season(self):
+        self.assertEqual(
+            subscription._build_cloud_extra_queries("隐身的名字", year="2026"),
+            ["隐身的名字 2026"],
+        )
+
+    def test_extra_queries_ignore_season_argument_removal(self):
+        self.assertEqual(
+            subscription._build_cloud_extra_queries("隐身的名字"),
+            [],
+        )
+
+    def test_strip_season_suffix_removes_manual_input_suffix(self):
+        self.assertEqual(subscription._strip_season_suffix("隐身的名字 第 1 季"), "隐身的名字")
+        self.assertEqual(subscription._strip_season_suffix("隐身的名字 S01"), "隐身的名字")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明
- 云资源搜索入口不再把季号拼进频道历史搜索关键词，仅保留片名和年份。
- 手动搜索请求入口会先剥离标题尾部季号，避免用户回显或手输把季号带回搜索词。
- 云资源模态框默认搜索标题改为去季号版本，避免 UI 误导。
- 增加回归测试，覆盖云资源搜索额外查询与季号剥离逻辑。

## 验证
- `python -m py_compile routes/subscription.py tests/test_cloud_resource_search_queries.py`
- `python -m unittest tests.test_cloud_resource_search_queries`
- `git diff --check`

## 说明
这次修复只调整云资源搜索行为，不影响前面 TG 候选解析和通知相关的提交。
