### PR TITLE
避免已处理剧集重复发送入库通知

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -713,18 +713,24 @@ def _handle_full_processing_flow(processor: 'MediaProcessor', item_id: str, forc
     logger.trace(f"  ➜ Webhook 任务及所有后续流程完成: '{item_name_for_log}'")
 
     # 4. ★★★ 通知分流 ★★★
-    try:
-        # 如果提供了 new_episode_ids，说明是追更通知
-        # 如果 is_new_item 为 True，说明是新入库通知
-        notif_type = 'update' if (new_episode_ids and not is_new_item) else 'new'
-        
-        telegram.send_media_notification(
-            item_details=item_details, 
-            notification_type=notif_type, 
-            new_episode_ids=new_episode_ids
+    should_send_notification = bool(is_new_item or new_episode_ids)
+    if should_send_notification:
+        try:
+            # 如果提供了 new_episode_ids，说明是追更通知
+            # 如果 is_new_item 为 True，说明是新入库通知
+            notif_type = 'update' if (new_episode_ids and not is_new_item) else 'new'
+
+            telegram.send_media_notification(
+                item_details=item_details,
+                notification_type=notif_type,
+                new_episode_ids=new_episode_ids
+            )
+        except Exception as e:
+            logger.error(f"触发通知失败: {e}")
+    else:
+        logger.info(
+            f"  ➜ 跳过媒体通知：'{item_name_for_log}' 已存在，且本次 Webhook 未携带新增分集。"
         )
-    except Exception as e:
-        logger.error(f"触发通知失败: {e}")
 
     logger.trace(f"  ➜ Webhook 任务及所有后续流程完成: '{item_name_for_log}'")
 

--- a/tests/test_webhook_task_retry.py
+++ b/tests/test_webhook_task_retry.py
@@ -65,10 +65,12 @@ def _install_test_stubs():
     emby_mod.get_emby_item_details = lambda *args, **kwargs: {}
     emby_mod.add_tags_to_item = lambda *args, **kwargs: None
     emby_mod.get_user_details = lambda *args, **kwargs: None
+    emby_mod.get_library_root_for_item = lambda *args, **kwargs: None
     sys.modules["handler.emby"] = emby_mod
 
     telegram_mod = sys.modules.get("handler.telegram") or types.ModuleType("handler.telegram")
     telegram_mod.send_playback_notification = lambda *args, **kwargs: None
+    telegram_mod.send_media_notification = lambda *args, **kwargs: None
     sys.modules["handler.telegram"] = telegram_mod
 
     config_manager_mod = sys.modules.get("config_manager") or types.ModuleType("config_manager")
@@ -139,6 +141,11 @@ def _install_test_stubs():
         mod = sys.modules.get(f"database.{name}") or types.ModuleType(f"database.{name}")
         if name == "media_db":
             mod.is_emby_id_in_library = lambda *args, **kwargs: False
+            mod.get_media_details = lambda *args, **kwargs: None
+        if name == "custom_collection_db":
+            mod.match_and_update_list_collections_on_item_add = lambda *args, **kwargs: []
+        if name == "settings_db":
+            mod.get_setting = lambda *args, **kwargs: {}
         if name == "watchlist_db":
             mod.get_watching_tmdb_ids = lambda: []
         if name == "queries_db":
@@ -171,6 +178,8 @@ def _install_test_stubs():
 
 _install_test_stubs()
 webhook = importlib.import_module("routes.webhook")
+if not hasattr(webhook.logger, "trace"):
+    webhook.logger.trace = lambda *args, **kwargs: None
 
 
 class WebhookTaskRetryTests(unittest.TestCase):
@@ -245,6 +254,96 @@ class WebhookTaskRetryTests(unittest.TestCase):
                 webhook._drain_pending_webhook_tasks()
         self.assertEqual(len(webhook.WEBHOOK_PENDING_TASKS), 1)
         spawn_later_mock.assert_called_once()
+
+    def test_existing_item_without_new_episodes_skips_media_notification(self):
+        processor = mock.MagicMock()
+        processor.process_single_item.return_value = True
+        processor.emby_url = "http://emby"
+        processor.emby_api_key = "key"
+        processor.emby_user_id = "user"
+
+        item_details = {
+            "Id": "series-1",
+            "Name": "永生",
+            "Type": "Series",
+            "ProviderIds": {"Tmdb": "123"},
+        }
+
+        with mock.patch.object(webhook.emby, "get_emby_item_details", return_value=item_details):
+            with mock.patch.object(webhook, "_submit_shared_auto_share_after_library_ready"):
+                with mock.patch.object(webhook.telegram, "send_media_notification") as notify_mock:
+                    webhook._handle_full_processing_flow(
+                        processor,
+                        "series-1",
+                        force_full_update=False,
+                        new_episode_ids=None,
+                        is_new_item=False,
+                    )
+
+        notify_mock.assert_not_called()
+
+    def test_existing_item_with_new_episodes_still_sends_update_notification(self):
+        processor = mock.MagicMock()
+        processor.process_single_item.return_value = True
+        processor.emby_url = "http://emby"
+        processor.emby_api_key = "key"
+        processor.emby_user_id = "user"
+
+        item_details = {
+            "Id": "series-1",
+            "Name": "永生",
+            "Type": "Series",
+            "ProviderIds": {"Tmdb": "123"},
+        }
+
+        with mock.patch.object(webhook.emby, "get_emby_item_details", return_value=item_details):
+            with mock.patch.object(webhook, "_submit_shared_auto_share_after_library_ready"):
+                with mock.patch.object(webhook.telegram, "send_media_notification") as notify_mock:
+                    webhook._handle_full_processing_flow(
+                        processor,
+                        "series-1",
+                        force_full_update=False,
+                        new_episode_ids=["ep-1"],
+                        is_new_item=False,
+                    )
+
+        notify_mock.assert_called_once_with(
+            item_details=item_details,
+            notification_type="update",
+            new_episode_ids=["ep-1"],
+        )
+
+    def test_new_item_still_sends_new_notification(self):
+        processor = mock.MagicMock()
+        processor.process_single_item.return_value = True
+        processor.emby_url = "http://emby"
+        processor.emby_api_key = "key"
+        processor.emby_user_id = "user"
+        processor.check_and_add_to_watchlist = mock.MagicMock()
+
+        item_details = {
+            "Id": "series-1",
+            "Name": "永生",
+            "Type": "Series",
+            "ProviderIds": {"Tmdb": "123"},
+        }
+
+        with mock.patch.object(webhook.emby, "get_emby_item_details", return_value=item_details):
+            with mock.patch.object(webhook, "_submit_shared_auto_share_after_library_ready"):
+                with mock.patch.object(webhook.telegram, "send_media_notification") as notify_mock:
+                    webhook._handle_full_processing_flow(
+                        processor,
+                        "series-1",
+                        force_full_update=False,
+                        new_episode_ids=None,
+                        is_new_item=True,
+                    )
+
+        notify_mock.assert_called_once_with(
+            item_details=item_details,
+            notification_type="new",
+            new_episode_ids=None,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 变更说明
- 修复已处理剧集在收到重复 `library.new` webhook 时仍被当作 `new` 通知发送的问题
- 仅在“真实新入库”或“明确携带新增分集”时发送媒体通知
- 为 webhook 通知分流补充回归测试，覆盖以下场景：
  - 已处理项目且无新增分集时不再发送通知
  - 已处理项目但有新增分集时仍发送 `update` 通知
  - 真正新入库时仍发送 `new` 通知

## 问题复现与根因
线上只读日志显示，同一剧集《永生》（Emby Item ID `541943`）在 `2026-06-05` 被 Emby 连续触发了三次 `library.new`：
- `12:20:24` -> `12:20:54`
- `12:22:52` -> `12:23:22`
- `12:26:44` -> `12:27:14`

三次任务里 `core_processor` 都已经命中：`媒体 '永生' 跳过已处理记录。`
但旧逻辑仍继续执行 `send_media_notification(..., notification_type='new')`，因此产生重复的“入库成功”通知。

## 验证
### 本地回归
- `python -m unittest tests.test_webhook_task_retry`
- `python -m unittest tests.test_telegram_media_notification`
- `python -m py_compile routes/webhook.py tests/test_webhook_task_retry.py tests/test_telegram_media_notification.py`
- `git diff --check`
- `bash /Users/paysen/Coding-local/emby-toolkit/.git-tools/etk-pr-check.sh`

### 线上证据
- 通过 Unraid 只读 `docker logs` 采样确认根因来自重复 `library.new`，未对线上容器做写操作或热补丁验证
