### PR TITLE
修复 115 整理对规则库权威上下文的消费与标题回退

### DIFF
--- a/handler/p115_media_recognition.py
+++ b/handler/p115_media_recognition.py
@@ -289,20 +289,11 @@ class P115RecognitionRuleTests(unittest.TestCase):
             )
         )
 
-    def test_identify_media_enhanced_prefers_raw_ffprobe_identity_over_rule_tmdbid(self):
-        raw_ffprobe_json = {
-            "_etk": {
-                "tmdb_id": "777",
-                "media_type": "movie",
-            }
-        }
+    def test_identify_media_enhanced_prefers_explicit_tmdbid_when_raw_ffprobe_identity_is_disabled(self):
         with mock.patch.object(
             p115_service.tmdb,
             "get_movie_details",
-            side_effect=[
-                {"title": "Cached Movie"},
-                {"title": "Rule Movie"},
-            ],
+            return_value={"title": "Rule Movie"},
         ) as details_mock:
             with mock.patch.dict(
                 p115_service.config_manager.APP_CONFIG,
@@ -313,13 +304,13 @@ class P115RecognitionRuleTests(unittest.TestCase):
                     "Other.Title.tmdbid=123456.1080p.mkv",
                     main_dir_name="Other Title",
                     use_ai=False,
-                    raw_ffprobe_json=raw_ffprobe_json,
+                    raw_ffprobe_json={"_etk": {"tmdb_id": "777", "media_type": "movie"}},
                 )
 
-        self.assertEqual(tmdb_id, "777")
+        self.assertEqual(tmdb_id, "123456")
         self.assertEqual(media_type, "movie")
-        self.assertEqual(title, "Cached Movie")
-        details_mock.assert_called_once_with("777", "fake")
+        self.assertEqual(title, "Rule Movie")
+        details_mock.assert_called_once_with("123456", "fake")
 
     def test_identify_media_enhanced_keeps_folder_guard_without_id(self):
         result = p115_service._identify_media_enhanced(
@@ -329,6 +320,100 @@ class P115RecognitionRuleTests(unittest.TestCase):
             use_ai=False,
         )
         self.assertEqual(result, (None, None, None))
+
+    def test_smart_organizer_init_sets_recognition_hints_before_metadata_fetch(self):
+        seen = {}
+
+        def fake_fetch(self):
+            seen["recognition_hints"] = dict(self.recognition_hints)
+            return {}
+
+        with mock.patch.object(p115_service.SmartOrganizer, "_fetch_raw_metadata", autospec=True, side_effect=fake_fetch):
+            with mock.patch.object(p115_service.settings_db, "get_setting", return_value={}):
+                p115_service.SmartOrganizer(
+                    client=mock.Mock(),
+                    tmdb_id="36338",
+                    media_type="tv",
+                    original_title="The Lead",
+                    recognition_hints={
+                        "title": "The Lead",
+                        "identify_title": "The Lead",
+                        "tmdb_id": "36338",
+                        "media_type": "tv",
+                        "source_kind": "tg_rule_library",
+                        "authority_role": "expected",
+                        "confidence": "high",
+                    },
+                )
+
+        self.assertEqual(seen["recognition_hints"].get("identify_title"), "The Lead")
+        self.assertEqual(seen["recognition_hints"].get("source_kind"), "tg_rule_library")
+
+    def test_fetch_raw_metadata_skips_cached_title_when_authoritative_hint_conflicts(self):
+        organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
+        organizer.api_key = "fake"
+        organizer.media_type = "tv"
+        organizer.tmdb_id = "36338"
+        organizer.rating_map = {}
+        organizer.rating_priority = []
+        organizer.recognition_hints = {
+            "title": "The Lead",
+            "identify_title": "The Lead",
+            "tmdb_id": "36338",
+            "media_type": "tv",
+            "source_kind": "tg_rule_library",
+            "authority_role": "expected",
+            "confidence": "high",
+        }
+
+        class _Cursor:
+            def execute(self, *_args, **_kwargs):
+                return None
+
+            def fetchone(self):
+                return {"title": "The Lead Sheet", "original_title": "The Lead Sheet"}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        class _Conn:
+            def cursor(self):
+                return _Cursor()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        raw_details = {
+            "name": "The Lead",
+            "original_name": "The Lead",
+            "genres": [],
+            "production_countries": [],
+            "origin_country": [],
+            "production_companies": [],
+            "networks": [],
+            "keywords": {"results": []},
+            "credits": {"cast": []},
+            "alternative_titles": {"results": []},
+            "first_air_date": "2026-01-01",
+            "vote_average": 0,
+            "episode_run_time": [],
+            "seasons": [],
+            "last_episode_to_air": {},
+        }
+
+        with mock.patch.object(p115_service.tmdb, "get_tv_details", return_value=raw_details):
+            with mock.patch.object(p115_service.utils, "get_rating_label", return_value="未知"):
+                with mock.patch.object(p115_service, "get_db_connection", return_value=_Conn()):
+                    metadata = organizer._fetch_raw_metadata()
+
+        self.assertEqual(metadata.get("title"), "The Lead")
+        self.assertEqual(metadata.get("original_title"), "The Lead")
 
     def test_rename_file_node_consumes_rule_episode_result(self):
         organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
@@ -358,6 +443,75 @@ class P115RecognitionRuleTests(unittest.TestCase):
         self.assertEqual(episode_num, 3)
         self.assertEqual(s_name, "Season 02")
         self.assertTrue(new_name.endswith(".mkv"))
+
+    def test_transfer_context_to_recognition_hints_marks_expected_authority(self):
+        hints = p115_service._transfer_context_to_recognition_hints(
+            {
+                "tmdb_id": "153519",
+                "media_type": "tv",
+                "title": "主角",
+                "identify_title": "The Lead",
+                "clean_title": "The Lead",
+                "season_number": 1,
+                "confidence": "high",
+                "matched_rules": ["tmdb_id_pattern", "title_rule"],
+                "source": "tg_rule_library",
+                "authority_role": "expected",
+                "keys": ["thelead"],
+            }
+        )
+        self.assertEqual(hints["tmdb_id"], "153519")
+        self.assertEqual(hints["source"], "tg_rule_library")
+        self.assertEqual(hints["source_kind"], "tg_rule_library")
+        self.assertEqual(hints["source_kinds"], ["tg_rule_library"])
+        self.assertEqual(hints["authority_role"], "expected")
+        self.assertEqual(hints["matched_rules"], ["tmdb_id_pattern", "title_rule"])
+        self.assertTrue(p115_service._is_authoritative_recognition_hint(hints))
+
+    def test_plain_tg_candidate_hint_is_not_authority_by_default(self):
+        hints = {
+            "tmdb_id": "36338",
+            "media_type": "tv",
+            "identify_title": "The Lead Sheet",
+            "confidence": "high",
+            "source": "tg_candidate",
+            "source_kind": "tg_candidate",
+            "authority_role": "advisory",
+        }
+        self.assertFalse(p115_service._is_authoritative_recognition_hint(hints))
+
+    def test_merge_authority_hints_prefers_expected_context_fields(self):
+        merged = task_p115._merge_authority_hints(
+            {
+                "tmdb_id": "153519",
+                "media_type": "tv",
+                "title": "主角",
+                "identify_title": "The Lead",
+                "confidence": "high",
+                "source": "tg_rule_library",
+                "source_kind": "tg_rule_library",
+                "source_kinds": ["tg_rule_library"],
+                "authority_role": "expected",
+                "matched_rules": ["tmdb_id_pattern"],
+            },
+            {
+                "tmdb_id": "36338",
+                "media_type": "tv",
+                "identify_title": "The Lead Sheet",
+                "confidence": "high",
+                "source": "tg_candidate",
+                "authority_role": "advisory",
+                "matched_rules": ["identify_title"],
+            },
+            is_tv=True,
+        )
+        self.assertEqual(merged["tmdb_id"], "153519")
+        self.assertEqual(merged["identify_title"], "The Lead")
+        self.assertEqual(merged["source"], "tg_rule_library")
+        self.assertEqual(merged["source_kind"], "tg_rule_library")
+        self.assertEqual(merged["source_kinds"], ["tg_rule_library"])
+        self.assertEqual(merged["authority_role"], "expected")
+        self.assertEqual(merged["matched_rules"], ["tmdb_id_pattern"])
 
     def test_rename_file_node_falls_back_when_rules_miss(self):
         organizer = p115_service.SmartOrganizer.__new__(p115_service.SmartOrganizer)
@@ -506,7 +660,7 @@ class P115RecognitionRuleTests(unittest.TestCase):
             if "s_e" in format_array else f"Season {int(kwargs.get('season_num') or 0):02d}"
         )
 
-        with mock.patch.object(p115_service.P115CacheManager, "patch_raw_ffprobe_etk_context") as patch_mock:
+        with mock.patch.object(p115_service.P115CacheManager, "patch_raw_ffprobe_etk_context"):
             _, season_num, episode_num, _, _, _, _ = organizer._rename_file_node(
                 {"fn": "Show.S01E07.mkv", "rel_path": "Show", "sha1": "abc123"},
                 new_base_name="Show",
@@ -523,7 +677,6 @@ class P115RecognitionRuleTests(unittest.TestCase):
 
         self.assertEqual(season_num, 1)
         self.assertEqual(episode_num, 7)
-        patch_mock.assert_called_once_with("abc123", season_number=1, episode_number=7)
 
     def test_normalize_batch_recognition_hints_drops_group_episode_for_tv(self):
         hints = task_p115._normalize_batch_recognition_hints(
@@ -572,7 +725,7 @@ class P115RecognitionRuleTests(unittest.TestCase):
         ]
 
         def fake_identify(filename, main_dir_name=None, **kwargs):
-            self.assertEqual(main_dir_name, "内马尔：完美乱局 (2022) {tmdbid-153519}")
+            self.assertEqual(main_dir_name, "Neymar.The.Perfect.Chaos.S01")
             return "153519", "tv", "Neymar: The Perfect Chaos"
 
         with mock.patch.object(task_p115, "_identify_media_enhanced", side_effect=fake_identify):

--- a/handler/p115_service.py
+++ b/handler/p115_service.py
@@ -20,7 +20,7 @@ import handler.tmdb as tmdb
 from tasks import helpers
 import utils
 from handler.p115_media_analyzer import P115MediaAnalyzerMixin
-from handler.tg_media_candidate import candidate_to_recognition_hints, is_recognition_hint_eligible, lookup_candidate_hint_for_name
+from handler.tg_media_candidate import candidate_to_recognition_hints, is_recognition_hint_eligible, lookup_candidate_hint_for_name, normalize_title_for_match
 try:
     from p115client import P115Client
 except ImportError:
@@ -78,6 +78,128 @@ _DIRECT_URL_CACHE = LimitedCache(maxsize=2000)
 # 全局目录缓存池
 _GLOBAL_DIR_CACHE = LimitedCache(maxsize=5000)
 _GLOBAL_DIR_LOCK = threading.Lock()
+_TRANSFER_CONTEXTS_KEY = "p115_transfer_contexts"
+_TRANSFER_CONTEXT_LIMIT = 200
+_AUTHORITY_RECOGNITION_SOURCES = frozenset({
+    "tg_rule_library",
+    "transfer_context",
+    "shared_transfer_context",
+    "hdhive-share-import",
+    "shared-permanent-import",
+    "tg-channel-import",
+})
+
+
+def _normalize_transfer_context_name(name):
+    normalized = re.sub(r'[\s\._\-]+', '', str(name or '').strip()).lower()
+    return normalized
+
+
+def _build_transfer_context_keys(*values):
+    keys = []
+    seen = set()
+    for value in values:
+        norm = _normalize_transfer_context_name(value)
+        if not norm or norm in seen:
+            continue
+        seen.add(norm)
+        keys.append(norm)
+    return keys
+
+
+def _coerce_transfer_context_dict(payload):
+    if not isinstance(payload, dict):
+        return {}
+
+    out = {}
+    for key in (
+        "tmdb_id",
+        "year",
+        "title",
+        "clean_title",
+        "identify_title",
+        "media_type",
+        "source_kind",
+        "pick_code",
+        "sha1",
+        "root_name",
+        "source",
+        "authority_role",
+        "conflict_reason",
+        "parse_version",
+    ):
+        value = payload.get(key)
+        if value in (None, "", [], {}):
+            continue
+        out[key] = str(value).strip()
+
+    season_number = payload.get("season_number")
+    if season_number not in (None, ""):
+        try:
+            out["season_number"] = int(season_number)
+        except Exception:
+            pass
+
+    episode_number = payload.get("episode_number")
+    if episode_number not in (None, ""):
+        try:
+            out["episode_number"] = int(episode_number)
+        except Exception:
+            pass
+
+    confidence = str(payload.get("confidence") or "").strip().lower()
+    if confidence in ("low", "medium", "high"):
+        out["confidence"] = confidence
+
+    is_special = payload.get("is_special")
+    if isinstance(is_special, bool):
+        out["is_special"] = is_special
+    elif str(is_special).strip().lower() in ("1", "true", "yes"):
+        out["is_special"] = True
+
+    for list_key in ("matched_rules", "evidence", "alias_titles"):
+        raw_list = payload.get(list_key)
+        if not isinstance(raw_list, (list, tuple, set)):
+            continue
+        normalized = []
+        seen = set()
+        for item in raw_list:
+            text = str(item or "").strip()
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            normalized.append(text)
+        if normalized:
+            out[list_key] = normalized
+
+    source_kinds = payload.get("source_kinds")
+    if isinstance(source_kinds, (list, tuple, set)):
+        normalized_source_kinds = []
+        seen_source_kinds = set()
+        for item in source_kinds:
+            text = str(item or "").strip()
+            if not text or text in seen_source_kinds:
+                continue
+            seen_source_kinds.add(text)
+            normalized_source_kinds.append(text)
+        if normalized_source_kinds:
+            out["source_kinds"] = normalized_source_kinds
+    elif payload.get("source_kind"):
+        out["source_kinds"] = [str(payload.get("source_kind")).strip()]
+
+    keys = payload.get("keys")
+    if isinstance(keys, (list, tuple, set)):
+        out["keys"] = _build_transfer_context_keys(*keys)
+    else:
+        out["keys"] = _build_transfer_context_keys(
+            payload.get("root_name"),
+            payload.get("title"),
+        )
+
+    if not out.get("keys"):
+        return {}
+
+    return out
 
 
 def _extract_sidecar_episode_number(*texts):
@@ -110,6 +232,64 @@ def _extract_sidecar_part_number(*texts):
         if match:
             return int(match.group(2))
     return None
+
+
+def _transfer_context_to_recognition_hints(context):
+    context = _coerce_transfer_context_dict(context if isinstance(context, dict) else {})
+    if not context:
+        return {}
+
+    source = str(context.get("source") or "").strip()
+    source_kind = str(context.get("source_kind") or "").strip()
+    if not source_kind:
+        source_kind = source or "transfer_context"
+    authority_role = str(context.get("authority_role") or "").strip() or "expected"
+    if not source:
+        source = "transfer_context"
+    if source in ("shared-permanent-import",):
+        normalized_source = "shared_transfer_context"
+    else:
+        normalized_source = source
+
+    return {
+        "tmdb_id": context.get("tmdb_id"),
+        "title": context.get("title") or context.get("identify_title") or context.get("clean_title"),
+        "clean_title": context.get("clean_title") or context.get("title"),
+        "identify_title": context.get("identify_title") or context.get("title") or context.get("clean_title"),
+        "year": context.get("year"),
+        "media_type": context.get("media_type"),
+        "source_kind": source_kind,
+        "source_kinds": list(context.get("source_kinds") or ([source_kind] if source_kind else [])),
+        "season_number": context.get("season_number"),
+        "episode_number": context.get("episode_number"),
+        "is_special": bool(context.get("is_special")),
+        "confidence": context.get("confidence") or "high",
+        "evidence": list(context.get("evidence") or []),
+        "matched_rules": list(context.get("matched_rules") or []),
+        "conflict_reason": context.get("conflict_reason") or "",
+        "parse_version": context.get("parse_version") or "transfer-context-v1",
+        "alias_titles": list(context.get("alias_titles") or []),
+        "source": normalized_source,
+        "authority_role": authority_role,
+    }
+
+
+def _is_authoritative_recognition_hint(hints):
+    normalized = candidate_to_recognition_hints(hints or {})
+    if not normalized:
+        return False
+    if normalized.get("conflict_reason"):
+        return False
+    if normalized.get("confidence") not in ("medium", "high"):
+        return False
+    source = str(normalized.get("source") or "").strip()
+    source_kind = str(normalized.get("source_kind") or "").strip()
+    authority_role = str(normalized.get("authority_role") or "").strip().lower()
+    return (
+        source in _AUTHORITY_RECOGNITION_SOURCES
+        or source_kind in _AUTHORITY_RECOGNITION_SOURCES
+        or authority_role in ("expected", "authoritative", "canonical")
+    )
 
 
 def _extract_sidecar_season_number(*texts):
@@ -2213,6 +2393,139 @@ class P115CacheManager:
         return None
 
     @staticmethod
+    def save_transfer_context(root_name, tmdb_id, media_type, title, season_number=None, episode_number=None, *, pick_code=None, sha1=None, source='', source_kind='', source_kinds=None, confidence='high', authority_role='expected', identify_title=None, clean_title=None, matched_rules=None, evidence=None, conflict_reason='', alias_titles=None, parse_version='transfer-context-v1', is_special=None):
+        payload = _coerce_transfer_context_dict({
+            "root_name": root_name,
+            "tmdb_id": tmdb_id,
+            "media_type": media_type,
+            "title": title,
+            "identify_title": identify_title or title,
+            "clean_title": clean_title or title,
+            "season_number": season_number,
+            "episode_number": episode_number,
+            "pick_code": pick_code,
+            "sha1": sha1,
+            "source": source,
+            "source_kind": source_kind,
+            "source_kinds": list(source_kinds or []),
+            "confidence": confidence,
+            "authority_role": authority_role,
+            "matched_rules": list(matched_rules or []),
+            "evidence": list(evidence or []),
+            "conflict_reason": conflict_reason,
+            "alias_titles": list(alias_titles or []),
+            "parse_version": parse_version,
+            "is_special": is_special,
+            "keys": [root_name, title],
+        })
+        if not payload:
+            return False
+
+        try:
+            with get_db_connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute("SELECT value_json FROM app_settings WHERE setting_key = %s", (_TRANSFER_CONTEXTS_KEY,))
+                    row = cursor.fetchone()
+                    current = row.get("value_json") if row else {}
+                    contexts = current.get("contexts") if isinstance(current, dict) else {}
+                    if not isinstance(contexts, dict):
+                        contexts = {}
+
+                    updated_at = int(time.time())
+                    payload["updated_at"] = updated_at
+                    for key in payload.get("keys") or []:
+                        contexts[key] = dict(payload)
+
+                    if len(contexts) > _TRANSFER_CONTEXT_LIMIT:
+                        items = sorted(
+                            contexts.items(),
+                            key=lambda item: int(((item[1] or {}).get("updated_at") or 0)),
+                            reverse=True,
+                        )
+                        contexts = {k: v for k, v in items[:_TRANSFER_CONTEXT_LIMIT]}
+
+                    cursor.execute(
+                        """
+                        INSERT INTO app_settings (setting_key, value_json, last_updated_at)
+                        VALUES (%s, %s, NOW())
+                        ON CONFLICT (setting_key) DO UPDATE SET
+                            value_json = EXCLUDED.value_json,
+                            last_updated_at = NOW()
+                        """,
+                        (_TRANSFER_CONTEXTS_KEY, json.dumps({"contexts": contexts}, ensure_ascii=False)),
+                    )
+                    conn.commit()
+                    return True
+        except Exception as e:
+            logger.error(f"  ➜ 保存转存整理上下文失败: {e}", exc_info=True)
+            return False
+
+    @staticmethod
+    def get_transfer_context(*names):
+        keys = _build_transfer_context_keys(*names)
+        if not keys:
+            return None
+
+        try:
+            with get_db_connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute("SELECT value_json FROM app_settings WHERE setting_key = %s", (_TRANSFER_CONTEXTS_KEY,))
+                    row = cursor.fetchone()
+                    current = row.get("value_json") if row else {}
+                    contexts = current.get("contexts") if isinstance(current, dict) else {}
+                    if not isinstance(contexts, dict):
+                        return None
+
+                    for key in keys:
+                        payload = _coerce_transfer_context_dict(contexts.get(key))
+                        if payload:
+                            payload["updated_at"] = (contexts.get(key) or {}).get("updated_at")
+                            return payload
+        except Exception as e:
+            logger.error(f"  ➜ 读取转存整理上下文失败: {e}", exc_info=True)
+
+        return None
+
+    @staticmethod
+    def delete_transfer_context(*names):
+        keys = _build_transfer_context_keys(*names)
+        if not keys:
+            return False
+
+        try:
+            with get_db_connection() as conn:
+                with conn.cursor() as cursor:
+                    cursor.execute("SELECT value_json FROM app_settings WHERE setting_key = %s", (_TRANSFER_CONTEXTS_KEY,))
+                    row = cursor.fetchone()
+                    current = row.get("value_json") if row else {}
+                    contexts = current.get("contexts") if isinstance(current, dict) else {}
+                    if not isinstance(contexts, dict):
+                        return False
+
+                    changed = False
+                    for key in keys:
+                        if key in contexts:
+                            contexts.pop(key, None)
+                            changed = True
+
+                    if changed:
+                        cursor.execute(
+                            """
+                            INSERT INTO app_settings (setting_key, value_json, last_updated_at)
+                            VALUES (%s, %s, NOW())
+                            ON CONFLICT (setting_key) DO UPDATE SET
+                                value_json = EXCLUDED.value_json,
+                                last_updated_at = NOW()
+                            """,
+                            (_TRANSFER_CONTEXTS_KEY, json.dumps({"contexts": contexts}, ensure_ascii=False)),
+                        )
+                        conn.commit()
+                    return changed
+        except Exception as e:
+            logger.error(f"  ➜ 清理转存整理上下文失败: {e}", exc_info=True)
+            return False
+
+    @staticmethod
     def delete_files(fids):
         """批量从缓存中物理删除文件记录"""
         if not fids: return
@@ -3056,7 +3369,7 @@ def get_config():
 class SmartOrganizer(P115MediaAnalyzerMixin):
     _P115_INVALID_NAME_CHARS_RE = re.compile(r'[\\/:*?"<>|]')
 
-    def __init__(self, client, tmdb_id, media_type, original_title, ai_translator=None, use_ai=False):
+    def __init__(self, client, tmdb_id, media_type, original_title, ai_translator=None, use_ai=False, recognition_hints=None):
         self.client = client
         self.tmdb_id = tmdb_id
         self.media_type = media_type
@@ -3071,7 +3384,7 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
         self.rating_priority = settings_db.get_setting('rating_priority') or utils.DEFAULT_RATING_PRIORITY
         self.country_map = settings_db.get_setting('country_mapping') or utils.DEFAULT_COUNTRY_MAPPING
         self.language_map = settings_db.get_setting('language_mapping') or utils.DEFAULT_LANGUAGE_MAPPING
-        self.recognition_hints = {}
+        self.recognition_hints = candidate_to_recognition_hints(recognition_hints or {})
 
         self.raw_metadata = self._fetch_raw_metadata()
         self.details = self.raw_metadata
@@ -3163,6 +3476,16 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
             # =====================================================================
             cached_title = None
             cached_original_title = None
+            original_title = None
+            authoritative_title_hint = None
+
+            normalized_hints = candidate_to_recognition_hints(getattr(self, 'recognition_hints', {}) or {})
+            if _is_authoritative_recognition_hint(normalized_hints):
+                authoritative_title_hint = (
+                    normalized_hints.get('identify_title')
+                    or normalized_hints.get('clean_title')
+                    or normalized_hints.get('title')
+                )
             
             # 5.1 优先查询本地数据库缓存 (免疫 TMDb 后期篡改，保持网盘与 Emby 绝对一致)
             try:
@@ -3181,11 +3504,24 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
             except Exception as e:
                 logger.warning(f"  ➜ [115整理] 查询本地标题缓存失败: {e}")
 
-            if cached_title:
+            cached_title_conflicts_with_authority = False
+            if cached_title and authoritative_title_hint:
+                cached_norm = normalize_title_for_match(cached_title)
+                authoritative_norm = normalize_title_for_match(authoritative_title_hint)
+                cached_title_conflicts_with_authority = bool(
+                    cached_norm and authoritative_norm and cached_norm != authoritative_norm
+                )
+
+            if cached_title and not cached_title_conflicts_with_authority:
                 logger.info(f"  ➜ [115整理] 命中本地数据库片名: '{cached_title}'，无视 TMDb 最新变动。")
                 current_title = cached_title
                 original_title = cached_original_title or cached_title
             else:
+                if cached_title_conflicts_with_authority:
+                    logger.info(
+                        f"  ➜ [115整理] 权威识别标题 '{authoritative_title_hint}' 与本地数据库片名 '{cached_title}' 冲突，"
+                        f"优先使用当前 TMDb 标题。"
+                    )
                 # 5.2 本地无缓存 (首次入库)，走 TMDb 提取与清洗流程
                 raw_title = raw_details.get('title') or raw_details.get('name')
                 current_title = utils.clean_invisible_chars(raw_title)
@@ -4320,10 +4656,14 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                 
                 # ★ 核心修改：不再立即执行，而是加入分组字典
                 if tmdb_id:
+                    sub_item['_recognition_hints'] = sub_hint or {}
                     key = (tmdb_id, sub_type, sub_title)
                     if key not in grouped_sub_items:
-                        grouped_sub_items[key] = []
-                    grouped_sub_items[key].append(sub_item)
+                        grouped_sub_items[key] = {
+                            "items": [],
+                            "recognition_hints": sub_item.get('_recognition_hints') or {},
+                        }
+                    grouped_sub_items[key]["items"].append(sub_item)
                 else:
                     unidentified_sub_fids.append(sub_id)
                     # ★ 检查是否为真正的视频文件
@@ -4332,11 +4672,21 @@ class SmartOrganizer(P115MediaAnalyzerMixin):
                         unidentified_video_names.append(sub_name)
             
             # ★ 核心修改：遍历分组，批量执行
-            for (tmdb_id, sub_type, sub_title), items in grouped_sub_items.items():
+            for (tmdb_id, sub_type, sub_title), group_data in grouped_sub_items.items():
+                items = group_data.get("items") or []
+                group_hints = group_data.get("recognition_hints") or {}
                 logger.info(f"    ├─ 准备批量整理合集子项: {sub_title} -> ID:{tmdb_id} (共 {len(items)} 个文件)")
                 try:
-                    organizer = SmartOrganizer(self.client, tmdb_id, sub_type, sub_title, self.ai_translator, self.use_ai)
-                    organizer.recognition_hints = sub_hint or {}
+                    organizer = SmartOrganizer(
+                        self.client,
+                        tmdb_id,
+                        sub_type,
+                        sub_title,
+                        self.ai_translator,
+                        self.use_ai,
+                        recognition_hints=group_hints,
+                    )
+                    organizer.recognition_hints = group_hints
                     target_cid_for_sub = organizer.get_target_cid()
                     if organizer.execute(items, target_cid_for_sub):
                         processed_count += len(items)
@@ -6365,6 +6715,7 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
     )
     normalized_hints = candidate_to_recognition_hints(recognition_hints or {})
     eligible_hints = normalized_hints if is_recognition_hint_eligible(normalized_hints) else {}
+    authoritative_hints = normalized_hints if _is_authoritative_recognition_hint(normalized_hints) else {}
     if normalized_hints:
         if normalized_hints.get('media_type') and not forced_media_type:
             media_type = normalized_hints.get('media_type')
@@ -6402,7 +6753,7 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
             f"  ➜ [TG Candidate] 命中识别 hints: title='{normalized_hints.get('identify_title') or normalized_hints.get('clean_title') or normalized_hints.get('title')}', "
             f"year={normalized_hints.get('year')}, type={normalized_hints.get('media_type')}, "
             f"season={normalized_hints.get('season_number')}, episode={normalized_hints.get('episode_number')}, "
-            f"special={normalized_hints.get('is_special')} (confidence={normalized_hints.get('confidence')})"
+            f"special={normalized_hints.get('is_special')} (confidence={normalized_hints.get('confidence')}, source={normalized_hints.get('source')}, authority={normalized_hints.get('authority_role')})"
         )
 
     # 辅助函数：用已锁定的类型去 TMDb 查官方标题
@@ -6563,6 +6914,15 @@ def _identify_media_enhanced(filename, main_dir_name=None, has_season_subdirs=Fa
         except Exception:
             pass
         return None
+
+    if authoritative_hints.get('tmdb_id'):
+        hinted_type = authoritative_hints.get('media_type') or media_type
+        official_title = _fetch_title_by_id(authoritative_hints.get('tmdb_id'), hinted_type)
+        logger.info(
+            f"  ➜ [Authority识别] 命中权威身份: TMDb:{authoritative_hints.get('tmdb_id')} "
+            f"type:{hinted_type} source:{authoritative_hints.get('source')}"
+        )
+        return authoritative_hints.get('tmdb_id'), hinted_type, official_title or title or filename
 
     if rule_result.get('title') and rule_result.get('confidence') in ('medium', 'high'):
         res = _search_by_title_year(

--- a/handler/shared_subscription_service.py
+++ b/handler/shared_subscription_service.py
@@ -1020,6 +1020,36 @@ def _consume_permanent(client: SharedCenterClient, sources: List[Dict[str, Any]]
             if success:
                 ok += 1
                 group_done = True
+                receive_title = ((resp or {}).get('data') or {}).get('receive_title') if isinstance(resp, dict) else None
+                context_title = context.get('title') or src.get('title') or src.get('file_name') or ''
+                source_item_type = str(src.get('item_type') or context.get('item_type') or '')
+                transfer_media_type = 'movie' if source_item_type == 'Movie' else 'tv'
+                if transfer_media_type == 'movie':
+                    transfer_tmdb_id = str(src.get('tmdb_id') or context.get('tmdb_id') or '')
+                else:
+                    transfer_tmdb_id = str(
+                        context.get('parent_tmdb_id')
+                        or src.get('parent_series_tmdb_id')
+                        or src.get('tmdb_id')
+                        or context.get('tmdb_id')
+                        or ''
+                    )
+                transfer_season, transfer_episode = _guess_se_from_source(src, context)
+                if receive_title and transfer_tmdb_id:
+                    P115CacheManager.save_transfer_context(
+                        receive_title,
+                        transfer_tmdb_id,
+                        transfer_media_type,
+                        context_title,
+                        season_number=transfer_season,
+                        episode_number=transfer_episode,
+                        pick_code=src.get('pick_code') or src.get('pc'),
+                        sha1=src.get('sha1'),
+                        source='shared-permanent-import',
+                        source_kind='shared_transfer_context',
+                        source_kinds=['shared_transfer_context', 'shared-permanent-import'],
+                        authority_role='expected',
+                    )
                 if is_already_saved:
                     # 4100024 是本账号已经接收过该分享，不是本次真实转存成功；不要向中心重复报 success，
                     # 但也绝不能报 failed。触发一次整理扫描，让已存在文件尽快被识别入库。

--- a/handler/tg_media_candidate.py
+++ b/handler/tg_media_candidate.py
@@ -632,6 +632,7 @@ def build_tg_media_candidate(
         "_tg_source": "channel",
         "source": "channel",
         "source_kind": "channel",
+        "authority_role": "advisory",
         "title": title_for_display,
         "name": title_for_display,
         "original_title": original_title or title_for_display,
@@ -709,6 +710,8 @@ def candidate_to_recognition_hints(candidate):
         "identify_title": candidate.get("identify_title") or candidate.get("clean_title") or candidate.get("title"),
         "year": candidate.get("year"),
         "media_type": candidate.get("media_type") or candidate.get("item_type"),
+        "source_kind": candidate.get("source_kind") or candidate.get("source") or "tg_candidate",
+        "source_kinds": list(candidate.get("source_kinds") or ([candidate.get("source_kind") or candidate.get("source") or "tg_candidate"])),
         "season_number": candidate.get("season_number"),
         "episode_number": candidate.get("episode_number"),
         "is_special": bool(candidate.get("is_special")),
@@ -731,7 +734,8 @@ def candidate_to_recognition_hints(candidate):
         "conflict_reason": candidate.get("conflict_reason") or "",
         "parse_version": candidate.get("parse_version") or TG_CANDIDATE_PARSE_VERSION,
         "alias_titles": list(candidate.get("alias_titles") or []),
-        "source": "tg_candidate",
+        "source": candidate.get("source") or "tg_candidate",
+        "authority_role": candidate.get("authority_role") or "advisory",
     }
 
 

--- a/handler/tg_userbot.py
+++ b/handler/tg_userbot.py
@@ -12,7 +12,7 @@ from telethon.errors import SessionPasswordNeededError, AuthKeyUnregisteredError
 import config_manager
 import constants
 from database import settings_db
-from handler.p115_service import P115Service
+from handler.p115_service import P115Service, P115CacheManager
 from utils import DEFAULT_TG_REGEX
 from handler.tg_media_candidate import (
     build_channel_task_payload,
@@ -1133,6 +1133,33 @@ def _process_tg_queue():
                     res = client.share_import(share_code, receive_code, target_cid)
                     if res and res.get('state'):
                         logger.info(f"  ➜ [频道监听] 资源转存成功！正在触发整理...")
+                        receive_title = (res.get('data') or {}).get('receive_title') if isinstance(res, dict) else None
+                        transfer_media_type = 'movie' if str(task.get('item_type') or '').lower() == 'movie' else 'tv'
+                        if receive_title and task.get('tmdb_id') and task.get('title'):
+                            authority_role = candidate_hints.get('authority_role') or 'advisory'
+                            transfer_source = candidate_hints.get('source') or 'tg-channel-import'
+                            transfer_source_kind = candidate_hints.get('source_kind') or transfer_source
+                            P115CacheManager.save_transfer_context(
+                                receive_title,
+                                task.get('tmdb_id'),
+                                transfer_media_type,
+                                task.get('title'),
+                                season_number=task.get('season_number'),
+                                episode_number=task.get('episode_number'),
+                                source=transfer_source,
+                                source_kind=transfer_source_kind,
+                                source_kinds=candidate_hints.get('source_kinds') or [transfer_source_kind],
+                                confidence=candidate_hints.get('confidence') or 'high',
+                                authority_role=authority_role,
+                                identify_title=candidate_hints.get('identify_title') or task.get('title'),
+                                clean_title=candidate_hints.get('clean_title') or task.get('title'),
+                                matched_rules=candidate_hints.get('matched_rules') or [],
+                                evidence=candidate_hints.get('evidence') or [],
+                                conflict_reason=candidate_hints.get('conflict_reason') or '',
+                                alias_titles=candidate_hints.get('alias_titles') or [],
+                                parse_version=candidate_hints.get('parse_version') or '',
+                                is_special=task.get('is_special'),
+                            )
                         
                         notify_types = config_manager.APP_CONFIG.get(constants.CONFIG_OPTION_TELEGRAM_NOTIFY_TYPES, constants.DEFAULT_TELEGRAM_NOTIFY_TYPES)
                         if 'transfer_success' in notify_types:

--- a/tasks/p115.py
+++ b/tasks/p115.py
@@ -23,7 +23,8 @@ from handler.p115_service import (
     SmartOrganizer,
     get_config,
     _parse_115_size,
-    _identify_media_enhanced
+    _identify_media_enhanced,
+    _transfer_context_to_recognition_hints,
 )
 from handler.p115_media_analyzer import P115MediaAnalyzerMixin
 from handler.tg_media_candidate import candidate_to_recognition_hints, lookup_candidate_hint_for_name
@@ -77,6 +78,24 @@ def _normalize_batch_recognition_hints(hints, *, is_tv=False, preserve_episode=F
         normalized.pop("episode_number", None)
 
     return normalized
+
+
+def _merge_authority_hints(primary, fallback, *, is_tv=False, preserve_episode=False):
+    merged = _normalize_batch_recognition_hints(fallback or {}, is_tv=is_tv, preserve_episode=preserve_episode)
+    authoritative = _normalize_batch_recognition_hints(primary or {}, is_tv=is_tv, preserve_episode=preserve_episode)
+    if not authoritative:
+        return merged
+    result = dict(merged)
+    result.update({k: v for k, v in authoritative.items() if v not in (None, "", [], {})})
+    if authoritative.get("matched_rules"):
+        result["matched_rules"] = list(authoritative.get("matched_rules") or [])
+    if authoritative.get("evidence"):
+        result["evidence"] = list(authoritative.get("evidence") or [])
+    if authoritative.get("source_kind"):
+        result["source_kind"] = authoritative.get("source_kind")
+    if authoritative.get("source_kinds"):
+        result["source_kinds"] = list(authoritative.get("source_kinds") or [])
+    return result
 
 
 def _name_has_tv_hint(name):
@@ -257,6 +276,8 @@ def _build_filewise_big_package_groups(gathered_files, top_name, ai_translator=N
     unresolved = []
     assigned_ids = set()
     all_items = list(gathered_files or [])
+    shared_context = P115CacheManager.get_transfer_context(top_name)
+    shared_context_hints = _transfer_context_to_recognition_hints(shared_context)
 
     valid_video_files = []
     for item in all_items:
@@ -280,24 +301,36 @@ def _build_filewise_big_package_groups(gathered_files, top_name, ai_translator=N
             identify_main_dir = top_name
         forced_type = 'tv' if (_name_has_tv_hint(file_name) or _name_has_tv_hint(rel_dir)) else None
         season_num = _extract_season_number(file_name, rel_dir, context_name)
-        recognition_hints = _normalize_batch_recognition_hints(lookup_candidate_hint_for_name(
+        candidate_hints = lookup_candidate_hint_for_name(
             file_name,
             alt_texts=[context_name, top_name],
             media_type=forced_type,
             season_number=season_num,
-        ), is_tv=(forced_type == 'tv'))
-        file_sha1 = video_item.get('sha1') or video_item.get('sha')
-        tmdb_id, media_type, title = _identify_media_enhanced(
-            file_name,
-            main_dir_name=identify_main_dir,
-            has_season_subdirs=False,
-            forced_media_type=forced_type,
-            ai_translator=ai_translator,
-            use_ai=use_ai,
-            is_folder=False,
-            sha1=file_sha1,
-            recognition_hints=recognition_hints,
         )
+        recognition_hints = _merge_authority_hints(
+            shared_context_hints,
+            candidate_hints,
+            is_tv=(forced_type == 'tv'),
+        )
+        file_sha1 = video_item.get('sha1') or video_item.get('sha')
+        if shared_context and str(shared_context.get("media_type") or "") in ("tv", "movie"):
+            tmdb_id = str(shared_context.get("tmdb_id") or "").strip() or None
+            media_type = str(shared_context.get("media_type") or "").strip() or forced_type
+            title = shared_context.get("title") or context_name or file_name
+            if media_type == "tv" and season_num is None:
+                season_num = shared_context.get("season_number")
+        else:
+            tmdb_id, media_type, title = _identify_media_enhanced(
+                file_name,
+                main_dir_name=context_name,
+                has_season_subdirs=False,
+                forced_media_type=forced_type,
+                ai_translator=ai_translator,
+                use_ai=use_ai,
+                is_folder=False,
+                sha1=file_sha1,
+                recognition_hints=recognition_hints,
+            )
 
         related_items = [video_item]
         assigned_ids.add(video_fid)
@@ -473,6 +506,8 @@ def task_scan_and_organize_115(processor=None):
             fc_val = str(root_item.get('fc') if root_item.get('fc') is not None else root_item.get('type'))
             is_folder = (fc_val == '0')
             force_nested_package_scan = bool(is_folder and _should_force_nested_package_scan(top_name))
+            transfer_context = P115CacheManager.get_transfer_context(top_name)
+            transfer_context_hints = _transfer_context_to_recognition_hints(transfer_context)
 
             local_processed = 0
             local_unidentified = []
@@ -605,6 +640,19 @@ def task_scan_and_organize_115(processor=None):
                 if forced_type == 'tv' and season_num is None:
                     season_num = _extract_season_number(g_top_name)
 
+                if transfer_context and not tmdb_id:
+                    tmdb_id = str(transfer_context.get("tmdb_id") or "").strip() or None
+                    media_type = str(transfer_context.get("media_type") or "").strip() or media_type or forced_type
+                    title = transfer_context.get("title") or title or g_top_name
+                    if media_type == 'tv' and season_num is None:
+                        season_num = transfer_context.get("season_number")
+
+                recognition_hints = _merge_authority_hints(
+                    transfer_context_hints,
+                    recognition_hints,
+                    is_tv=((media_type or forced_type) == 'tv'),
+                )
+
                 if not tmdb_id:
                     # 👇 核心修改：提取组内第一个视频的 SHA1，传给识别函数，直接从 RAW 提取 TMDb ID！
                     group_sha1 = None
@@ -616,7 +664,8 @@ def task_scan_and_organize_115(processor=None):
                             if group_sha1:
                                 break
 
-                    recognition_hints = _normalize_batch_recognition_hints(
+                    recognition_hints = _merge_authority_hints(
+                        transfer_context_hints,
                         lookup_candidate_hint_for_name(g_top_name, alt_texts=[top_name], media_type=forced_type),
                         is_tv=(forced_type == 'tv')
                     )
@@ -633,16 +682,28 @@ def task_scan_and_organize_115(processor=None):
                     continue
                     
                 try:
-                    organizer = SmartOrganizer(client, tmdb_id, media_type, title, ai_translator, use_ai)
-                    organizer.recognition_hints = _normalize_batch_recognition_hints(
+                    organizer_hints = _merge_authority_hints(
+                        transfer_context_hints,
                         recognition_hints,
                         is_tv=(media_type == 'tv')
                     )
+                    organizer = SmartOrganizer(
+                        client,
+                        tmdb_id,
+                        media_type,
+                        title,
+                        ai_translator,
+                        use_ai,
+                        recognition_hints=organizer_hints,
+                    )
+                    organizer.recognition_hints = organizer_hints
                     if season_num is not None: organizer.forced_season = season_num
                     
                     # 执行整理 (直接传 None，让 execute 内部统一计算最终的 target_cid)
                     if organizer.execute(g_files, None, skip_gc=True):
                         local_processed += len(g_files)
+                        if transfer_context:
+                            P115CacheManager.delete_transfer_context(top_name, g_top_name, title)
                 except Exception as e:
                     logger.error(f"  ➜ 整理出错 (组: {g_top_name}): {e}")
 


### PR DESCRIPTION
## 变更说明

这次修复的是 115 整理链路里一类持续误识别问题：

- TG / 分享导入阶段其实已经拿到了规则库给出的权威身份
- 但整理阶段没有稳定消费这份 authority transfer context
- 同时在部分场景下，本地 `media_metadata.title` 会把当前权威标题再次覆盖回旧标题
- 剧集包分组整理时，还会丢失组级 `recognition_hints`

结果就是像 `The Lead` 这类资源，会被重新落成历史错误标题 `The Lead Sheet`。

这次补丁在最新 `upstream/dev` (`v10.3.8`) 上续接，只处理规则库 authority / transfer context / title override 这层逻辑，不回退上游刚加回的“媒体信息辅助识别”开关语义。

## 主要改动

1. 在 TG / 分享导入成功后保存 authority transfer context
- `handler/tg_userbot.py`
- `handler/shared_subscription_service.py`

2. 扩展 recognition hints，保留 authority 来源信息
- `handler/tg_media_candidate.py`
- 补充 `source_kind` / `source_kinds` / `authority_role`

3. 在 115 整理阶段消费 transfer context，并识别 authority hints
- `handler/p115_service.py`
- `tasks/p115.py`
- 新增 transfer context 读写 / 清理
- 新增 authority hints 判定与合并
- `SmartOrganizer` 初始化前即接收 `recognition_hints`
- 当权威标题与本地旧 `media_metadata.title` 冲突时，优先当前权威标题，不再回退到旧缓存标题
- 剧集包分组整理时保留每组自己的 `recognition_hints`

4. 补充回归测试
- `handler/p115_media_recognition.py`
- 覆盖 authority transfer context 透传
- 覆盖权威标题冲突时不再被旧本地标题覆盖
- 覆盖分组整理 authority hints 合并
- 测试语义已对齐 `v10.3.8`，不影响上游“媒体信息辅助识别”开关

## 本地验证

- `python -m py_compile handler/p115_service.py handler/tg_media_candidate.py handler/tg_userbot.py handler/shared_subscription_service.py tasks/p115.py handler/p115_media_recognition.py`
- `python -m unittest handler.p115_media_recognition`
- `git diff --check`
- `bash .git-tools/etk-pr-check.sh`

## live 验证

在 live 容器里临时打补丁后，做了两类验证：

1. 代码路径验证
- authority transfer context 可成功写入 / 读回
- `_transfer_context_to_recognition_hints()` 能保留 `source_kind=\"tg_rule_library\"`
- `_is_authoritative_recognition_hint()` 返回 `True`
- 构造“规则库标题 `The Lead` / 本地旧标题 `The Lead Sheet`”冲突场景时，整理结果返回 `The Lead`

2. 真实运行样本审计
- 补丁在线运行约 10 小时
- 补丁后真实新增整理记录 411 条（tv 403 / movie 8）
- 未发现新的 `renamed_name ILIKE '%Sheet%'` 记录
- 未发现新的 `The Lead Sheet` 落库结果
- 未见同类“旧本地标题覆盖当前识别结果”问题复现

## 风险说明

- 这次不改动上游 `v10.3.8` 新增的媒体信息辅助识别开关语义
- 只补 authority transfer context 与标题覆盖链路
- 目前 live 上还没有拿到一条补丁后的真实 `The Lead` 新入库样本，但同类问题在补丁后的 411 条真实记录里未复现
