### PR TITLE
修复系统自动更新后 Docker Helper 临时容器残留

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -13,6 +13,14 @@ import constants # 你的常量定义
 logger = logging.getLogger(__name__)
 
 
+def _log_trace(message):
+    trace_logger = getattr(logger, 'trace', None)
+    if callable(trace_logger):
+        trace_logger(message)
+        return
+    logger.debug(message)
+
+
 def _notify_pending_system_update_result():
     try:
         from tasks.system_update import peek_post_update_status, clear_post_update_status
@@ -80,7 +88,7 @@ def retry_pending_system_update_result(max_attempts: int = 10, interval_seconds:
             return True
         if attempt < max_attempts:
             time.sleep(interval_seconds)
-    logger.trace("  ➜ 系统更新结果通知重试结束，仍未成功发送。")
+    _log_trace("  ➜ 系统更新结果通知重试结束，仍未成功发送。")
     return False
 
 # --- 路径和配置定义 ---

--- a/tasks/system_update.py
+++ b/tasks/system_update.py
@@ -18,6 +18,10 @@ DEFAULT_IMAGE_NAME_TAG = 'hbq0405/emby-toolkit:latest'
 DEFAULT_UPDATE_STRATEGY = 'docker_helper'
 DEFAULT_HELPER_IMAGE = 'hbq0405/emby-toolkit:latest'
 UPDATE_STATUS_FILE = 'system_update_result.json'
+DOCKER_HELPER_LABELS = {
+    'com.embytoolkit.role': 'system-update-helper',
+    'com.embytoolkit.target-container': DEFAULT_CONTAINER_NAME,
+}
 
 DOCKER_HELPER_SCRIPT = r"""
 import json
@@ -576,6 +580,12 @@ def _build_helper_environment(status_path, container_name, image_name_tag, versi
     }
 
 
+def _build_helper_labels(container_name):
+    labels = dict(DOCKER_HELPER_LABELS)
+    labels['com.embytoolkit.target-container'] = _clean_version_text(container_name, DEFAULT_CONTAINER_NAME)
+    return labels
+
+
 def _ensure_helper_image(client, helper_image, version_info):
     try:
         client.images.get(helper_image)
@@ -633,10 +643,11 @@ def _run_docker_helper(client, helper_image, container_name, image_name_tag, ver
         output = client.containers.run(
             image=helper_image,
             entrypoint=["python", "-c", DOCKER_HELPER_SCRIPT],
-            remove=True,
             detach=False,
+            auto_remove=True,
             environment=env,
             volumes=volumes,
+            labels=_build_helper_labels(container_name),
         )
         logger.debug(f"Docker helper 输出: {_decode_container_output(output)}")
     except Exception as e:

--- a/tests/test_system_update_post_notify.py
+++ b/tests/test_system_update_post_notify.py
@@ -195,15 +195,18 @@ class PostUpdateNotifyTests(unittest.TestCase):
             "target_version": "v10.2.6",
             "message": "容器健康检查通过。",
         }
+        user_db_mod = sys.modules["database.user_db"]
+        telegram_mod = sys.modules["handler.telegram"]
         with mock.patch("tasks.system_update.peek_post_update_status", return_value=payload):
             with mock.patch("tasks.system_update.clear_post_update_status", return_value=True) as clear_mock:
-                with mock.patch("handler.telegram.send_telegram_message") as send_mock:
-                    result = config_manager._notify_pending_system_update_result()
+                with mock.patch.object(user_db_mod, "get_admin_telegram_chat_ids", return_value=["10001"]):
+                    with mock.patch.object(telegram_mod, "send_telegram_message") as send_mock:
+                        result = config_manager._notify_pending_system_update_result()
 
         self.assertTrue(result)
         send_mock.assert_called_once()
         clear_mock.assert_called_once()
-        message = send_mock.call_args.args[1]
+        message = send_mock.call_args.args[1].replace("\\", "")
         self.assertIn("系统自动更新", message)
         self.assertIn("10.2.5", message)
         self.assertIn("v10.2.6", message)
@@ -216,10 +219,13 @@ class PostUpdateNotifyTests(unittest.TestCase):
             "target_version": "v10.2.6",
             "message": "容器健康检查通过。",
         }
+        user_db_mod = sys.modules["database.user_db"]
+        telegram_mod = sys.modules["handler.telegram"]
         with mock.patch("tasks.system_update.peek_post_update_status", return_value=payload):
             with mock.patch("tasks.system_update.clear_post_update_status", return_value=True) as clear_mock:
-                with mock.patch("handler.telegram.send_telegram_message", side_effect=RuntimeError("tg down")):
-                    result = config_manager._notify_pending_system_update_result()
+                with mock.patch.object(user_db_mod, "get_admin_telegram_chat_ids", return_value=["10001"]):
+                    with mock.patch.object(telegram_mod, "send_telegram_message", side_effect=RuntimeError("tg down")):
+                        result = config_manager._notify_pending_system_update_result()
 
         self.assertFalse(result)
         clear_mock.assert_not_called()

--- a/tests/test_system_update_post_notify.py
+++ b/tests/test_system_update_post_notify.py
@@ -90,6 +90,7 @@ def _install_stubs():
     constants_mod.CONFIG_OPTION_ETK_SERVER_URL = "etk_server_url"
     constants_mod.CONFIG_OPTION_115_ENABLE_SYNC_DELETE = "p115_enable_sync_delete"
     constants_mod.CONFIG_OPTION_115_GENERATE_MEDIAINFO = "p115_generate_mediainfo"
+    constants_mod.CONFIG_OPTION_115_MEDIAINFO_ASSISTED_RECOGNITION = "p115_mediainfo_assisted_recognition"
     constants_mod.CONFIG_OPTION_115_DOWNLOAD_SUBS = "p115_download_subs"
     constants_mod.CONFIG_OPTION_115_LOCAL_CLEANUP = "p115_local_cleanup"
     constants_mod.CONFIG_OPTION_115_MEDIAINFO_CENTER = "p115_mediainfo_center"

--- a/tests/test_system_update_post_notify.py
+++ b/tests/test_system_update_post_notify.py
@@ -6,7 +6,18 @@ from unittest import mock
 
 
 def _install_stubs():
-    constants_mod = sys.modules.get("constants") or types.ModuleType("constants")
+    for module_name in [
+        "config_manager",
+        "constants",
+        "database",
+        "database.settings_db",
+        "database.user_db",
+        "handler.telegram",
+        "tasks.system_update",
+    ]:
+        sys.modules.pop(module_name, None)
+
+    constants_mod = types.ModuleType("constants")
     constants_mod.CONFIG_FILE_NAME = "config.ini"
     constants_mod.CONFIG_OPTION_DB_HOST = "db_host"
     constants_mod.CONFIG_OPTION_DB_PORT = "db_port"
@@ -144,27 +155,27 @@ def _install_stubs():
     constants_mod.ENV_VAR_TMDB_API_BASE_URL = "TMDB_API_BASE_URL"
     sys.modules["constants"] = constants_mod
 
-    settings_db_mod = sys.modules.get("database.settings_db") or types.ModuleType("database.settings_db")
+    settings_db_mod = types.ModuleType("database.settings_db")
     settings_db_mod.get_setting = lambda key: {}
     settings_db_mod.save_setting = lambda key, value: None
     settings_db_mod.delete_setting = lambda key: True
 
-    user_db_mod = sys.modules.get("database.user_db") or types.ModuleType("database.user_db")
+    user_db_mod = types.ModuleType("database.user_db")
     user_db_mod.get_admin_telegram_chat_ids = lambda: ["10001"]
 
-    database_pkg = sys.modules.get("database") or types.ModuleType("database")
+    database_pkg = types.ModuleType("database")
     database_pkg.settings_db = settings_db_mod
     database_pkg.user_db = user_db_mod
     sys.modules["database"] = database_pkg
     sys.modules["database.settings_db"] = settings_db_mod
     sys.modules["database.user_db"] = user_db_mod
 
-    handler_telegram_mod = sys.modules.get("handler.telegram") or types.ModuleType("handler.telegram")
+    handler_telegram_mod = types.ModuleType("handler.telegram")
     handler_telegram_mod.send_telegram_message = lambda *args, **kwargs: None
     handler_telegram_mod.escape_markdown = lambda text: text
     sys.modules["handler.telegram"] = handler_telegram_mod
 
-    tasks_system_update = sys.modules.get("tasks.system_update") or types.ModuleType("tasks.system_update")
+    tasks_system_update = types.ModuleType("tasks.system_update")
     tasks_system_update.consume_post_update_status = lambda: None
     tasks_system_update.peek_post_update_status = lambda: None
     tasks_system_update.clear_post_update_status = lambda: True

--- a/tests/test_telegram_system_update_notification.py
+++ b/tests/test_telegram_system_update_notification.py
@@ -6,13 +6,34 @@ from unittest import mock
 
 
 def _install_test_stubs():
-    config_manager_mod = sys.modules.get("config_manager") or types.ModuleType("config_manager")
+    for module_name in [
+        "config_manager",
+        "constants",
+        "extensions",
+        "handler.emby",
+        "handler.tg_media_candidate",
+        "handler.p115_service",
+        "handler.github",
+        "handler.telegram",
+        "docker",
+        "task_manager",
+        "tasks.core",
+        "tasks.system_update",
+        "database",
+        "database.user_db",
+        "database.request_db",
+        "database.media_db",
+        "database.connection",
+    ]:
+        sys.modules.pop(module_name, None)
+
+    config_manager_mod = types.ModuleType("config_manager")
     config_manager_mod.APP_CONFIG = {}
     config_manager_mod.PERSISTENT_DATA_PATH = "/tmp"
     config_manager_mod.get_proxies_for_requests = lambda: None
     sys.modules["config_manager"] = config_manager_mod
 
-    constants_mod = sys.modules.get("constants") or types.ModuleType("constants")
+    constants_mod = types.ModuleType("constants")
     constants_mod.APP_VERSION = "10.2.3"
     constants_mod.CONFIG_OPTION_TELEGRAM_BOT_TOKEN = "telegram_bot_token"
     constants_mod.CONFIG_OPTION_TELEGRAM_CHANNEL_ID = "telegram_channel_id"
@@ -28,44 +49,44 @@ def _install_test_stubs():
     constants_mod.GITHUB_REPO_NAME = "emby-toolkit"
     sys.modules["constants"] = constants_mod
 
-    extensions_mod = sys.modules.get("extensions") or types.ModuleType("extensions")
+    extensions_mod = types.ModuleType("extensions")
     extensions_mod.media_processor_instance = types.SimpleNamespace(config={})
     extensions_mod.watchlist_processor_instance = types.SimpleNamespace(config={})
     extensions_mod.actor_subscription_processor_instance = types.SimpleNamespace(config={})
     sys.modules["extensions"] = extensions_mod
 
-    emby_mod = sys.modules.get("handler.emby") or types.ModuleType("handler.emby")
+    emby_mod = types.ModuleType("handler.emby")
     emby_mod.get_emby_item_details = lambda *args, **kwargs: {}
     sys.modules["handler.emby"] = emby_mod
 
-    tg_candidate_mod = sys.modules.get("handler.tg_media_candidate") or types.ModuleType("handler.tg_media_candidate")
+    tg_candidate_mod = types.ModuleType("handler.tg_media_candidate")
     tg_candidate_mod.build_channel_task_payload = lambda *args, **kwargs: {}
     sys.modules["handler.tg_media_candidate"] = tg_candidate_mod
 
-    p115_service_mod = sys.modules.get("handler.p115_service") or types.ModuleType("handler.p115_service")
+    p115_service_mod = types.ModuleType("handler.p115_service")
     p115_service_mod.P115Service = object
     sys.modules["handler.p115_service"] = p115_service_mod
 
-    github_mod = sys.modules.get("handler.github") or types.ModuleType("handler.github")
+    github_mod = types.ModuleType("handler.github")
     github_mod.get_github_releases = lambda *args, **kwargs: [{"version": "v10.2.4"}]
     sys.modules["handler.github"] = github_mod
 
-    docker_mod = sys.modules.get("docker") or types.ModuleType("docker")
+    docker_mod = types.ModuleType("docker")
     docker_mod.from_env = lambda: None
     docker_mod.errors = types.SimpleNamespace(NotFound=Exception, ImageNotFound=Exception)
     sys.modules["docker"] = docker_mod
 
-    task_manager_mod = sys.modules.get("task_manager") or types.ModuleType("task_manager")
+    task_manager_mod = types.ModuleType("task_manager")
     task_manager_mod.update_status_from_thread = lambda *args, **kwargs: None
     sys.modules["task_manager"] = task_manager_mod
 
-    tasks_core_mod = sys.modules.get("tasks.core") or types.ModuleType("tasks.core")
+    tasks_core_mod = types.ModuleType("tasks.core")
     tasks_core_mod.get_task_registry = lambda context="all": {}
     sys.modules["tasks.core"] = tasks_core_mod
 
-    database_pkg = sys.modules.get("database") or types.ModuleType("database")
+    database_pkg = types.ModuleType("database")
     for name in ["user_db", "request_db", "media_db"]:
-        mod = sys.modules.get(f"database.{name}") or types.ModuleType(f"database.{name}")
+        mod = types.ModuleType(f"database.{name}")
         if name == "user_db":
             mod.get_admin_telegram_chat_ids = lambda: []
             mod.get_user_telegram_chat_id = lambda *args, **kwargs: None
@@ -77,7 +98,7 @@ def _install_test_stubs():
         sys.modules[f"database.{name}"] = mod
     sys.modules["database"] = database_pkg
 
-    database_connection_mod = sys.modules.get("database.connection") or types.ModuleType("database.connection")
+    database_connection_mod = types.ModuleType("database.connection")
     database_connection_mod.get_db_connection = lambda: None
     sys.modules["database.connection"] = database_connection_mod
 

--- a/tests/test_telegram_system_update_notification.py
+++ b/tests/test_telegram_system_update_notification.py
@@ -368,8 +368,11 @@ class TelegramSystemUpdateNotificationTests(unittest.TestCase):
         self.assertEqual(kwargs["entrypoint"][0:2], ["python", "-c"])
         self.assertIn("if __name__ == \"__main__\":", kwargs["entrypoint"][2])
         self.assertNotIn("/tmp/etk_update_helper.py", kwargs["entrypoint"][2])
+        self.assertTrue(kwargs["auto_remove"])
         self.assertEqual(kwargs["volumes"]["/srv/etk-config"], {"bind": "/config", "mode": "rw"})
         self.assertEqual(kwargs["environment"]["ETK_UPDATE_STATUS_PATH"], "/config/system_update_result.json")
+        self.assertEqual(kwargs["labels"]["com.embytoolkit.role"], "system-update-helper")
+        self.assertEqual(kwargs["labels"]["com.embytoolkit.target-container"], "emby-toolkit")
 
     def test_run_docker_helper_fails_fast_when_status_path_is_not_persisted_mount(self):
         fake_client = mock.Mock()

--- a/tests/test_telegram_system_update_notification.py
+++ b/tests/test_telegram_system_update_notification.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+import threading
 import types
 import unittest
 from unittest import mock
@@ -71,6 +72,12 @@ def _install_test_stubs():
     github_mod.get_github_releases = lambda *args, **kwargs: [{"version": "v10.2.4"}]
     sys.modules["handler.github"] = github_mod
 
+    telegram_mod = types.ModuleType("handler.telegram")
+    telegram_mod.send_telegram_message = lambda *args, **kwargs: None
+    telegram_mod.escape_markdown = lambda text: text
+    telegram_mod.threading = threading
+    sys.modules["handler.telegram"] = telegram_mod
+
     docker_mod = types.ModuleType("docker")
     docker_mod.from_env = lambda: None
     docker_mod.errors = types.SimpleNamespace(NotFound=Exception, ImageNotFound=Exception)
@@ -104,6 +111,7 @@ def _install_test_stubs():
 
 
 _install_test_stubs()
+sys.modules.pop("handler.telegram", None)
 telegram = importlib.import_module("handler.telegram")
 system_update = importlib.import_module("tasks.system_update")
 
@@ -285,14 +293,15 @@ class TelegramSystemUpdateNotificationTests(unittest.TestCase):
             with mock.patch.object(system_update, "resolve_update_target", return_value={"container_name": "etk-prod", "docker_image_name": "hbq0405/emby-toolkit:v10.2.4"}):
                 with mock.patch.object(system_update, "resolve_update_strategy", return_value={"strategy": "docker_helper", "helper_image": "hbq0405/emby-toolkit:latest"}):
                     with mock.patch.object(telegram, "send_telegram_message") as send_mock:
-                        with mock.patch("handler.telegram.threading.Thread") as thread_mock:
+                        with mock.patch.object(telegram.threading, "Thread") as thread_mock:
                             thread_mock.return_value.start.side_effect = lambda: thread_mock.call_args.kwargs["target"]()
 
                             registry = {
                                 "system-auto-update": (fake_update_task, "系统自动更新", "media")
                             }
-                            with mock.patch("tasks.core.get_task_registry", return_value=registry):
-                                telegram._execute_task_from_tg("10001", "system-auto-update")
+                            with mock.patch.dict(sys.modules, {"tasks.system_update": system_update}):
+                                with mock.patch("tasks.core.get_task_registry", return_value=registry):
+                                    telegram._execute_task_from_tg("10001", "system-auto-update")
 
         self.assertEqual(send_mock.call_count, 2)
         start_message = send_mock.call_args_list[0].args[1]


### PR DESCRIPTION
问题背景

Unraid live 容器在系统自动更新成功后，会遗留多个已退出的匿名容器，例如：
- `sharp_jemison`
- `cranky_jones`
- `beautiful_leavitt`
- `laughing_chatelet`
- `optimistic_hypatia`
- `exciting_mclaren`

只读取证确认这些容器都具有相同特征：
- 镜像为 `hbq0405/emby-toolkit:latest`
- 入口为 `python -c`
- 环境变量包含 `ETK_TARGET_CONTAINER=emby-toolkit`

这说明它们不是业务容器，而是 Docker Helper 自动更新的临时容器残留。

根因分析

当前 Docker Helper 是通过：
- `client.containers.run(..., detach=False, remove=True)`
来启动。

但系统自动更新时，helper 会把当前 ETK 容器自己停掉并重建。这样会导致：
- 调用 `containers.run()` 的当前进程先被杀掉
- Docker SDK 来不及在调用返回后继续执行清理路径
- helper 容器虽然已经退出，但不会被删除，最终在 Docker / Unraid 中留下匿名 exited 容器

这不是更新失败，而是 helper 清理时机依赖了调用方进程存活。

本次修复

1. 改为由 Docker daemon 负责 helper 自动清理
- helper 启动参数从 `remove=True` 改为 `auto_remove=True`
- 让容器退出时由 Docker daemon 直接清除，而不是依赖当前 ETK 进程在 helper 返回后再清理

2. 给 helper 临时容器增加固定 label
- `com.embytoolkit.role=system-update-helper`
- `com.embytoolkit.target-container=<container_name>`

这样后续即使要排查或做只读审计，也能精确识别 helper 容器，不会误判为普通业务容器。

3. 补齐 `config_manager` 的 trace 回退
- `retry_pending_system_update_result()` 不再硬依赖 `logger.trace`
- 在轻量测试/最小运行环境下会回退到 `debug`

4. 修复 system-update 回归测试的模块污染问题
- 两个回归测试模块都改成显式清理并重建 stub 模块
- 修复组合执行顺序导致的 `sys.modules` 污染
- 让 `git etk-pr-check` 稳定通过，不再出现顺序相关假红

测试与验证

代码级验证：
```bash
python -m py_compile tasks/system_update.py config_manager.py tests/test_telegram_system_update_notification.py tests/test_system_update_post_notify.py
python -m unittest tests.test_telegram_system_update_notification tests.test_system_update_post_notify
bash /Users/paysen/Coding-local/emby-toolkit/.git-tools/etk-pr-check.sh --base upstream/dev
```

本地 Docker 完整 E2E 验证：
1. 构建当前修复镜像：
- `etk-sandbox:codex-system-update-helper-auto-remove`
- image id: `ec210b307237...`

2. 构建旧基线镜像（基于最新 `upstream/dev`，不含本次 auto-remove 修复）：
- `etk-sandbox:auto-update-base`
- image id: `0287a27a0860...`

3. 用旧基线镜像启动本地沙箱后，更新到当前修复镜像：
- 容器成功切到 `ec210b307237...`
- 容器恢复 `healthy`
- 会残留一个 helper exited 容器
- 这一步符合预期，因为发起更新的是旧基线逻辑，不含本次修复

4. 再构造一个“包含本次修复、但 image id 不同”的变体镜像：
- `localhost:5000/etk-sandbox:auto-update-variant`
- image id: `6a57a1daf41b...`

5. 用“已经包含本次修复”的当前容器，再更新到该变体镜像：
- `emby-toolkit-sandbox` 成功从 `ec210b307237...` 切到 `6a57a1daf41b...`
- 新容器恢复 `healthy`
- `docker ps -a --filter label=com.embytoolkit.role=system-update-helper` 返回空
- 没有新增 helper 残留容器

这一步才是真正证明本次 `auto_remove` 修复生效的关键证据。

影响范围

本次修改仅影响 Docker Helper 自动更新的临时容器清理与相关回归测试，不影响普通业务任务流程。
