### PR TITLE
统一系统自动更新通知中的版本号格式

### DIFF
--- a/tasks/system_update.py
+++ b/tasks/system_update.py
@@ -18,6 +18,15 @@ DEFAULT_IMAGE_NAME_TAG = 'hbq0405/emby-toolkit:latest'
 DEFAULT_UPDATE_STRATEGY = 'docker_helper'
 DEFAULT_HELPER_IMAGE = 'hbq0405/emby-toolkit:latest'
 UPDATE_STATUS_FILE = 'system_update_result.json'
+
+
+def _normalize_version_tag(value):
+    text = _clean_version_text(value)
+    if not text:
+        return None
+    if text.lower().startswith('v'):
+        return f"v{text[1:]}"
+    return f"v{text}"
 DOCKER_HELPER_LABELS = {
     'com.embytoolkit.role': 'system-update-helper',
     'com.embytoolkit.target-container': DEFAULT_CONTAINER_NAME,
@@ -529,7 +538,7 @@ def resolve_update_strategy(config_source=None):
 
 
 def get_system_update_version_info():
-    current_version = _clean_version_text(getattr(constants, 'APP_VERSION', None), '0.0.0')
+    current_version = _normalize_version_tag(getattr(constants, 'APP_VERSION', None)) or 'v0.0.0'
     target_version = None
 
     try:
@@ -541,7 +550,7 @@ def get_system_update_version_info():
             proxies=config_manager.get_proxies_for_requests(),
         ) or []
         if releases:
-            target_version = _clean_version_text(releases[0].get('version'))
+            target_version = _normalize_version_tag((releases[0] or {}).get('version'))
     except Exception as e:
         logger.debug(f"获取最新版本信息失败，将继续执行更新检查: {e}")
 

--- a/tests/test_telegram_system_update_notification.py
+++ b/tests/test_telegram_system_update_notification.py
@@ -279,6 +279,17 @@ class TelegramSystemUpdateNotificationTests(unittest.TestCase):
         self.assertEqual(resolved["container_name"], "etk-prod")
         self.assertEqual(resolved["docker_image_name"], "hbq0405/emby-toolkit:v10.2.4")
 
+    def test_get_system_update_version_info_normalizes_version(self):
+        fake_release = {
+            "version": "v10.2.4",
+        }
+
+        with mock.patch.object(system_update.github, "get_github_releases", return_value=[fake_release]):
+            info = system_update.get_system_update_version_info()
+
+        self.assertEqual(info["current_version"], "v10.2.3")
+        self.assertEqual(info["target_version"], "v10.2.4")
+
     def test_system_update_tg_notification_uses_real_result_and_versions(self):
         def fake_update_task(processor):
             return {
@@ -289,7 +300,10 @@ class TelegramSystemUpdateNotificationTests(unittest.TestCase):
                 "target_version": "v10.2.4",
             }
 
-        with mock.patch.object(system_update, "get_system_update_version_info", return_value={"current_version": "10.2.3", "target_version": "v10.2.4"}):
+        with mock.patch.object(system_update, "get_system_update_version_info", return_value={
+            "current_version": "v10.2.3",
+            "target_version": "v10.2.4",
+        }):
             with mock.patch.object(system_update, "resolve_update_target", return_value={"container_name": "etk-prod", "docker_image_name": "hbq0405/emby-toolkit:v10.2.4"}):
                 with mock.patch.object(system_update, "resolve_update_strategy", return_value={"strategy": "docker_helper", "helper_image": "hbq0405/emby-toolkit:latest"}):
                     with mock.patch.object(telegram, "send_telegram_message") as send_mock:
@@ -308,7 +322,7 @@ class TelegramSystemUpdateNotificationTests(unittest.TestCase):
         finish_message = send_mock.call_args_list[1].args[1]
         normalized_start = start_message.replace("\\", "")
         normalized_finish = finish_message.replace("\\", "")
-        self.assertIn("当前版本: `10.2.3`", normalized_start)
+        self.assertIn("当前版本: `v10.2.3`", normalized_start)
         self.assertIn("目标版本: `v10.2.4`", normalized_start)
         self.assertIn("目标容器: `etk-prod`", normalized_start)
         self.assertIn("目标镜像: `hbq0405/emby-toolkit:v10.2.4`", normalized_start)


### PR DESCRIPTION
问题背景

系统自动更新启动通知中的版本展示不一致：
- 当前版本来自 `constants.APP_VERSION`，显示为 `10.5.2`
- 目标版本来自 GitHub tag，显示为 `v10.5.5`

最终在 Telegram 通知中会看到：
- `当前版本: 10.5.2`
- `目标版本: v10.5.5`

这会让用户误以为当前版本格式异常，或者误判两者来源不一致。

本次修复

- 对系统自动更新展示用版本号做统一归一化
- 无论来源是 `10.5.2` 还是 `v10.5.5`，通知里都统一显示为 `v...` 格式

示例：
- `10.5.2` -> `v10.5.2`
- `v10.5.5` -> `v10.5.5`

影响范围

本次修改仅影响系统自动更新通知中的版本展示格式，不影响实际更新逻辑。

验证结果

```bash
python -m py_compile handler/telegram.py tasks/system_update.py tests/test_telegram_system_update_notification.py
python -m unittest tests.test_telegram_system_update_notification
git diff --check
```
