### PR TITLE
兼容路径式 STRM 的 115 全量同步

### DIFF
--- a/config_manager.py
+++ b/config_manager.py
@@ -204,6 +204,7 @@ DYNAMIC_CONFIG_DEF = {
     constants.CONFIG_OPTION_115_MEDIAINFO_ASSISTED_RECOGNITION: (constants.CONFIG_SECTION_115, 'boolean', False),
     constants.CONFIG_OPTION_115_DOWNLOAD_SUBS: (constants.CONFIG_SECTION_115, 'boolean', True),
     constants.CONFIG_OPTION_115_LOCAL_CLEANUP: (constants.CONFIG_SECTION_115, 'boolean', False),
+    constants.CONFIG_OPTION_115_AUTO_CLEAN_EMPTY_DIRS: (constants.CONFIG_SECTION_115, 'boolean', True),
     constants.CONFIG_OPTION_115_MEDIAINFO_CENTER: (constants.CONFIG_SECTION_115, "boolean", False),
     constants.CONFIG_OPTION_115_APP_ID: (constants.CONFIG_SECTION_115, 'string', ""),
     constants.CONFIG_OPTION_115_LIFE_MONITOR_ENABLED: (constants.CONFIG_SECTION_115, "boolean", False),

--- a/constants.py
+++ b/constants.py
@@ -66,6 +66,7 @@ CONFIG_OPTION_115_GENERATE_MEDIAINFO = "p115_generate_mediainfo" # 是否生成M
 CONFIG_OPTION_115_MEDIAINFO_ASSISTED_RECOGNITION = "p115_mediainfo_assisted_recognition" # 是否启用MediaInfo辅助识别
 CONFIG_OPTION_115_DOWNLOAD_SUBS = "p115_download_subs"           # 是否下载字幕文件
 CONFIG_OPTION_115_LOCAL_CLEANUP = "p115_local_cleanup"           # 是否启用本地清理功能
+CONFIG_OPTION_115_AUTO_CLEAN_EMPTY_DIRS = "p115_auto_clean_empty_dirs" # 整理后是否自动清理115待整理目录空目录
 CONFIG_OPTION_115_MEDIAINFO_CENTER = "p115_mediainfo_center"     # 分布式媒体信息
 CONFIG_OPTION_115_APP_ID = "p115_app_id"                         # 115 自定义 AppID
 CONFIG_OPTION_115_LIFE_MONITOR_ENABLED = "p115_life_monitor_enabled" # 是否开启生活事件监控

--- a/handler/p115_service.py
+++ b/handler/p115_service.py
@@ -4537,6 +4537,15 @@ class P115DeleteBuffer:
 
     @classmethod
     def add(cls, fids=None, base_cids=None, check_save_path=False):
+        if check_save_path:
+            config = get_config()
+            auto_clean = config.get(constants.CONFIG_OPTION_115_AUTO_CLEAN_EMPTY_DIRS, True)
+            if not auto_clean:
+                logger.info("  ➜ [清理空目录] 自动检查待整理目录已关闭，跳过本次全局垃圾回收。")
+                check_save_path = False
+                if not fids and not base_cids:
+                    return
+
         with cls._lock:
             if fids:
                 cls._fids_to_delete.update(fids)

--- a/tasks/p115.py
+++ b/tasks/p115.py
@@ -56,6 +56,35 @@ KNOWN_SKIP_EXTS = {'clpi', 'mpls', 'bdmv', 'jar', 'bup', 'ifo'}
 MIN_BIG_PACKAGE_VIDEO_SIZE = 50 * 1024 * 1024
 
 
+def _is_path_style_strm_for_file(content, file_name):
+    text = str(content or "").strip()
+    if not text or not file_name:
+        return False
+
+    lower_text = text.lower()
+    if lower_text.startswith(("http://", "https://")) or "/api/p115/play/" in lower_text:
+        return False
+
+    if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", text) and not lower_text.startswith("file://"):
+        return False
+
+    if lower_text.startswith("file://"):
+        text = text[7:]
+
+    text = text.split("?", 1)[0].split("#", 1)[0].replace("\\", "/").rstrip("/")
+    existing_name = os.path.basename(text)
+    if not existing_name:
+        return False
+
+    try:
+        from urllib.parse import unquote
+        existing_name = unquote(existing_name)
+    except Exception:
+        pass
+
+    return existing_name == file_name
+
+
 def _normalize_batch_recognition_hints(hints, *, is_tv=False, preserve_episode=False):
     """
     批量整理时，组级 hints 只能安全复用标题/TMDb/季级信息。
@@ -1281,12 +1310,17 @@ def task_full_sync_strm_and_subs(processor=None):
                                         content = f"{content}/{name}"
                                 
                                 need_write = True
+                                preserved_existing_path_strm = False
                                 if os.path.exists(strm_path):
                                     try:
                                         with open(strm_path, 'r', encoding='utf-8') as f:
                                             old_content = f.read().strip()
                                             if old_content == content: 
                                                 need_write = False
+                                            elif not etk_url.startswith('http') and _is_path_style_strm_for_file(old_content, name):
+                                                need_write = False
+                                                preserved_existing_path_strm = True
+                                                logger.debug(f"  ➜ [保留] 已存在路径模式 STRM，跳过覆盖: {strm_name}")
                                             else:
                                                 logger.debug(f"  ➜ [更新] 内容不一致触发覆盖 -> 旧: [{old_content}] | 新: [{content}]")
                                     except Exception as e: pass
@@ -1305,7 +1339,7 @@ def task_full_sync_strm_and_subs(processor=None):
                                 # ==================================================
                                 # ★ 生成 Mediainfo (等同 MP 直出逻辑)
                                 # ==================================================
-                                if config.get(constants.CONFIG_OPTION_115_GENERATE_MEDIAINFO, False):
+                                if config.get(constants.CONFIG_OPTION_115_GENERATE_MEDIAINFO, False) and not preserved_existing_path_strm:
                                     mediainfo_filename = os.path.splitext(name)[0] + "-mediainfo.json"
                                     mediainfo_filepath = os.path.join(current_local_path, mediainfo_filename)
                                     


### PR DESCRIPTION
## 背景

部分用户使用 CD2/rclone 等挂载路径形式的外部 STRM，STRM 内容不是 ETK `/api/p115/play/{pickcode}` 链接，而是类似 `/cd2/115open/Media/.../*.mkv` 的本地/挂载路径。此时执行「全量生成 STRM」虽然可以同步 115 文件信息和补齐 `p115_filesystem_cache`，但如果覆盖已有 STRM，会导致 Emby 将文件视作变更并重新提取媒体信息。

同时，整理后的 `P115DeleteBuffer.add(check_save_path=True)` 会触发待整理目录空目录检查，在大目录/频繁整理场景下可能产生较多 `/files` 请求。

## 修改内容

- 在路径模式（`etk_server_url` 非 HTTP）下识别已有路径式 STRM：
  - 非 HTTP/HTTPS；
  - 非 `/api/p115/play/`；
  - 文件名 basename 与当前 115 文件名一致。
- 命中已有路径式 STRM 时跳过覆盖，不修改文件内容、mtime、size。
- 即使跳过 STRM 写入，仍继续写入 `p115_filesystem_cache`，用于后续 pickcode/SHA1 指纹补齐。
- 跳过保留的外部 STRM 时不额外生成 `-mediainfo.json`，避免在用户已有库旁产生新文件。
- 新增 `p115_auto_clean_empty_dirs` 配置项，默认 `true` 保持原行为；关闭时跳过 `check_save_path=True` 触发的全局空目录清理。

## 兼容性

- 默认配置不变：`p115_auto_clean_empty_dirs=true`。
- HTTP/pickcode STRM 模式仍按原逻辑覆盖更新。
- 已有 `/api/p115/play/...` STRM 不会被当成路径式 STRM 保留。
- 路径式 STRM 只有 basename 与当前文件名匹配时才保留，降低误保留风险。

## 验证

本地验证：

- `python -m py_compile constants.py config_manager.py handler/p115_service.py tasks/p115.py`
- `git diff --check`
- 最小 dry run：伪造一个 115 视频和已有 `/cd2/115open/Media/.../Movie.mkv` STRM，执行 `task_full_sync_strm_and_subs` 后确认：
  - STRM 内容不变；
  - mtime 不变；
  - size 不变；
  - 未生成 mediainfo sidecar；
  - `P115CacheManager.save_file_cache(...)` 正常写入 `pick_code/sha1/local_path`。
- 反向 dry run：HTTP `etk_server_url` 下仍覆盖为 `http://.../api/p115/play/{pickcode}`。

Live 容器验证（Unraid，app 用户执行）：

- 单电影样本《007：大战皇家赌场》：执行受控全量 STRM 同步后，既有 CD2 路径式 STRM 内容、size、mtime 均未改变，`p115_filesystem_cache` 新增对应 `fid/pick_code/sha1/local_path`。
- 随后仅用本地 cache、禁用 API 补齐媒体指纹，电影库 `file_pickcode_json/file_sha1_json` 从 600 个补到 3463 个，新增 2863 个，`api_fixed_assets=0`。
- 关闭 `p115_auto_clean_empty_dirs` 后，整理触发的待整理目录空目录 GC 不再继续产生高频 `/files` 请求。
