### PR TITLE
兼容外部路径 STRM 的 115 同步与指纹补齐

### DIFF
--- a/tasks/p115.py
+++ b/tasks/p115.py
@@ -56,6 +56,76 @@ KNOWN_SKIP_EXTS = {'clpi', 'mpls', 'bdmv', 'jar', 'bup', 'ifo'}
 MIN_BIG_PACKAGE_VIDEO_SIZE = 50 * 1024 * 1024
 
 
+def _normalize_path_style_strm_content(content):
+    text = str(content or "").strip()
+    if not text:
+        return ""
+
+    lower_text = text.lower()
+    if lower_text.startswith(("http://", "https://")) or "/api/p115/play/" in lower_text:
+        return ""
+
+    has_file_scheme = lower_text.startswith("file://")
+    if re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", text) and not has_file_scheme:
+        return ""
+
+    if has_file_scheme:
+        text = text[7:]
+
+    normalized = text.split("?", 1)[0].split("#", 1)[0].replace("\\", "/").rstrip("/")
+    if (
+        has_file_scheme
+        or normalized.startswith("/")
+        or normalized.startswith("//")
+        or re.match(r"^[a-zA-Z]:/", normalized)
+    ):
+        return normalized
+    return ""
+
+
+def _is_path_style_strm(content):
+    return bool(_normalize_path_style_strm_content(content))
+
+
+def _path_style_strm_conflict_type(old_content, new_content):
+    old_path = _normalize_path_style_strm_content(old_content)
+    new_path = _normalize_path_style_strm_content(new_content)
+    if not old_path or not new_path or old_path == new_path:
+        return ""
+
+    old_dir = os.path.dirname(old_path).replace("\\", "/").rstrip("/")
+    new_dir = os.path.dirname(new_path).replace("\\", "/").rstrip("/")
+    old_base = os.path.basename(old_path)
+    new_base = os.path.basename(new_path)
+    old_stem, old_ext = os.path.splitext(old_base)
+    new_stem, new_ext = os.path.splitext(new_base)
+
+    if old_dir == new_dir and old_stem == new_stem and old_ext.lower() != new_ext.lower():
+        return "same_stem_different_ext"
+    return "path_mismatch"
+
+
+def _p115_response_path_contains_cid(response, target_cid):
+    path_nodes = response.get('path') if isinstance(response, dict) else None
+    if not path_nodes:
+        return True
+
+    target = str(target_cid or '')
+    for node in path_nodes:
+        if not isinstance(node, dict):
+            continue
+        node_id = str(
+            node.get('cid')
+            or node.get('file_id')
+            or node.get('id')
+            or node.get('parent_id')
+            or ''
+        )
+        if node_id == target:
+            return True
+    return False
+
+
 def _normalize_batch_recognition_hints(hints, *, is_tv=False, preserve_episode=False):
     """
     批量整理时，组级 hints 只能安全复用标题/TMDb/季级信息。
@@ -1194,7 +1264,7 @@ def task_full_sync_strm_and_subs(processor=None):
             return None
 
         def process_full_sync_items(items, target_cid, category_name):
-            nonlocal files_generated, subs_downloaded
+            nonlocal files_generated, subs_downloaded, path_strm_preserved
             for item in items:
                 # 兼容 OpenAPI、Cookie 和 p115client 标准化字段
                 name = item.get('fn') or item.get('n') or item.get('file_name') or item.get('name', '')
@@ -1240,12 +1310,26 @@ def task_full_sync_strm_and_subs(processor=None):
                             content = f"{content}/{name}"
 
                     need_write = True
+                    preserved_existing_path_strm = False
                     if os.path.exists(strm_path):
                         try:
                             with open(strm_path, 'r', encoding='utf-8') as f:
                                 old_content = f.read().strip()
                                 if old_content == content:
                                     need_write = False
+                                elif not etk_url.startswith('http') and _is_path_style_strm(old_content):
+                                    need_write = False
+                                    preserved_existing_path_strm = True
+                                    path_strm_preserved += 1
+                                    conflict_type = _path_style_strm_conflict_type(old_content, content)
+                                    if conflict_type:
+                                        path_strm_conflicts[conflict_type] = path_strm_conflicts.get(conflict_type, 0) + 1
+                                        if conflict_type == 'same_stem_different_ext':
+                                            logger.warning(f"  ➜ [冲突] 已存在路径模式 STRM，同名不同后缀，已跳过覆盖: {strm_name} | 旧: [{old_content}] | 新: [{content}]")
+                                        else:
+                                            logger.warning(f"  ➜ [冲突] 已存在路径模式 STRM，路径不一致，已跳过覆盖: {strm_name} | 旧: [{old_content}] | 新: [{content}]")
+                                    else:
+                                        logger.debug(f"  ➜ [保留] 已存在路径模式 STRM，跳过覆盖: {strm_name}")
                                 else:
                                     logger.debug(f"  ➜ [更新] 内容不一致触发覆盖 -> 旧: [{old_content}] | 新: [{content}]")
                         except Exception:
@@ -1264,7 +1348,7 @@ def task_full_sync_strm_and_subs(processor=None):
                     sha1 = item.get('sha1') or item.get('sha')
 
                     # 生成 Mediainfo (等同 MP 直出逻辑)
-                    if config.get(constants.CONFIG_OPTION_115_GENERATE_MEDIAINFO, False):
+                    if config.get(constants.CONFIG_OPTION_115_GENERATE_MEDIAINFO, False) and not preserved_existing_path_strm:
                         mediainfo_filename = os.path.splitext(name)[0] + "-mediainfo.json"
                         mediainfo_filepath = os.path.join(current_local_path, mediainfo_filename)
 
@@ -1398,6 +1482,11 @@ def task_full_sync_strm_and_subs(processor=None):
         valid_local_files = set()
         files_generated = 0
         subs_downloaded = 0
+        path_strm_preserved = 0
+        path_strm_conflicts = {
+            'same_stem_different_ext': 0,
+            'path_mismatch': 0,
+        }
         
         fetch_types = [4] # 4=视频
         if download_subs: fetch_types.append(1) # 1=文档(含字幕)
@@ -1407,6 +1496,7 @@ def task_full_sync_strm_and_subs(processor=None):
         for idx, target_cid in enumerate(target_cids):
             category_name = cid_to_rel_path.get(target_cid, "未知分类")
             base_prog = 10 + int((idx / total_targets) * 80)
+            target_invalid = False
             fast_count = run_cookie_fast_sync(target_cid, category_name, base_prog)
             if processor and getattr(processor, 'is_stop_requested', lambda: False)():
                 return
@@ -1434,6 +1524,14 @@ def task_full_sync_strm_and_subs(processor=None):
                             logger.error(f"  ➜ API 返回异常状态 (可能触发流控): {res}")
                             sync_has_errors = True
                             break
+                        if not _p115_response_path_contains_cid(res, target_cid):
+                            logger.warning(
+                                f"  ➜ [{category_name}] OpenAPI 返回路径不包含目标 cid={target_cid}，"
+                                "可能远端目录已删除或本地缓存过期，已跳过该分类的兜底同步。"
+                            )
+                            sync_has_errors = True
+                            target_invalid = True
+                            break
                         data = res.get('data', [])
                         if not data: break
                         
@@ -1448,8 +1546,17 @@ def task_full_sync_strm_and_subs(processor=None):
                         logger.error(f"  ➜ 全局拉取异常 (cid={target_cid}, type={f_type}): {e}")
                         sync_has_errors = True
                         break
+                if target_invalid:
+                    break
 
         logger.info(f"  ➜ 增量同步完成！新增/更新 STRM: {files_generated} 个, 下载字幕: {subs_downloaded} 个。")
+        if path_strm_preserved:
+            logger.info(
+                "  ➜ 路径模式 STRM 保护：跳过覆盖 %s 个，其中同名不同后缀 %s 个，路径不一致 %s 个。",
+                path_strm_preserved,
+                path_strm_conflicts.get('same_stem_different_ext', 0),
+                path_strm_conflicts.get('path_mismatch', 0),
+            )
 
         # =================================================================
         # 阶段 3: 本地失效文件清理 (耗时: 秒级)

--- a/tasks/p115_fingerprint_helpers.py
+++ b/tasks/p115_fingerprint_helpers.py
@@ -69,7 +69,12 @@ def p115_fp_read_strm_target(path: str) -> Optional[str]:
         return None
 
 
-def p115_fp_build_local_path_candidates(path: str, strm_target: Optional[str], local_root: str = '') -> List[str]:
+def p115_fp_build_local_path_candidates(
+    path: str,
+    strm_target: Optional[str],
+    local_root: str = '',
+    mount_prefix: str = '',
+) -> List[str]:
     """
     为挂载模式/STRM 模式构造 p115_filesystem_cache.local_path 候选值。
     - 标准 STRM：asset path 是 .strm，本地缓存是同目录真实视频扩展名。
@@ -85,12 +90,14 @@ def p115_fp_build_local_path_candidates(path: str, strm_target: Optional[str], l
             return
 
         variants = [cleaned]
-        if local_root:
+        for root in (local_root, mount_prefix):
+            if not root:
+                continue
             try:
-                root_norm = os.path.normpath(local_root).replace('\\', '/').rstrip('/')
+                root_norm = os.path.normpath(str(root)).replace('\\', '/').rstrip('/')
                 path_norm = os.path.normpath(cleaned).replace('\\', '/')
                 if path_norm == root_norm:
-                    return
+                    continue
                 if path_norm.startswith(root_norm + '/'):
                     variants.append(path_norm[len(root_norm):].lstrip('/'))
             except Exception:
@@ -184,6 +191,42 @@ def _merge_cache_row(cache_row, values: Dict[str, Any]) -> bool:
     return changed
 
 
+def _p115_fp_cache_values_complete(values: Dict[str, Any]) -> bool:
+    return bool(
+        values.get('fid')
+        and values.get('parent_id')
+        and values.get('name')
+        and values.get('sha1')
+        and values.get('pc')
+        and values.get('size')
+    )
+
+
+def _p115_fp_lookup_cache(P115CacheManager, values: Dict[str, Any], local_candidates: List[str]):
+    if not P115CacheManager:
+        return None
+
+    if values.get('pc'):
+        cache_row = P115CacheManager.get_file_cache_by_pickcode(values['pc'])
+        if cache_row:
+            return cache_row
+    if values.get('sha1'):
+        cache_row = P115CacheManager.get_file_cache_by_sha1(values['sha1'])
+        if cache_row:
+            return cache_row
+    if values.get('fid'):
+        cache_row = P115CacheManager.get_file_cache_by_id(values['fid'])
+        if cache_row:
+            return cache_row
+
+    for local_candidate in local_candidates:
+        cache_row = P115CacheManager.get_file_cache_by_local_path(local_candidate)
+        if cache_row:
+            return cache_row
+
+    return None
+
+
 def _row_to_dict(row) -> Dict[str, Any]:
     if isinstance(row, dict):
         return dict(row)
@@ -223,6 +266,37 @@ def _parse_size_to_bytes(size_val) -> int:
     except Exception:
         pass
     return 0
+
+def _get_mount_prefix_for_fingerprint(processor=None) -> str:
+    candidates = []
+    try:
+        cfg = getattr(processor, 'config', None) or {}
+        value = cfg.get('etk_server_url') if isinstance(cfg, dict) else ''
+        if value:
+            candidates.append(value)
+    except Exception:
+        pass
+    try:
+        import config_manager
+        value = (config_manager.APP_CONFIG or {}).get('etk_server_url')
+        if value:
+            candidates.append(value)
+    except Exception:
+        pass
+    try:
+        from handler.p115_service import get_config
+        value = (get_config() or {}).get('etk_server_url')
+        if value:
+            candidates.append(value)
+    except Exception:
+        pass
+
+    for value in candidates:
+        text = str(value or '').strip().replace('\\', '/').rstrip('/')
+        if text and not re.match(r'^https?://', text, re.IGNORECASE):
+            return text
+    return ''
+
 
 def _get_asset_size(asset: Dict[str, Any]) -> int:
     val = (
@@ -276,6 +350,7 @@ def repair_p115_fingerprints_for_rows(
         client = None
 
     video_exts = video_exts or VIDEO_EXTS
+    mount_prefix = _get_mount_prefix_for_fingerprint(processor)
     rows = [_row_to_dict(row) for row in rows]
     total_rows = len(rows)
 
@@ -340,7 +415,12 @@ def repair_p115_fingerprints_for_rows(
                 stats['missing_assets'] += 1
 
             strm_target = p115_fp_read_strm_target(clean_path)
-            local_candidates = p115_fp_build_local_path_candidates(clean_path, strm_target, local_root)
+            local_candidates = p115_fp_build_local_path_candidates(
+                clean_path,
+                strm_target,
+                local_root,
+                mount_prefix=mount_prefix,
+            )
             
             # ★ 优化 2：防止 .strm 污染 115 真实文件名
             base_name = os.path.basename(clean_path) if clean_path else None
@@ -350,11 +430,25 @@ def repair_p115_fingerprints_for_rows(
             # ★ 核心修复：防止绝对路径污染 local_path
             # 仅当明确配置了 local_root 且成功剥离出相对路径时，才作为候选写入
             best_local_path = None
-            if local_root and local_candidates:
-                shortest = min(local_candidates, key=len)
-                # 如果最短的候选路径比原始路径短，说明成功剥离了 local_root
-                if len(shortest) < len(clean_path):
-                    best_local_path = shortest
+            if local_candidates:
+                absolute_path = p115_fp_clean_path(strm_target or clean_path) or clean_path
+                relative_candidates = []
+                for candidate in local_candidates:
+                    if not candidate:
+                        continue
+                    if not os.path.isabs(candidate) and not re.match(r'^[a-zA-Z]:/', candidate):
+                        relative_candidates.append(candidate)
+                if relative_candidates:
+                    video_candidates = [
+                        candidate for candidate in relative_candidates
+                        if os.path.splitext(candidate)[1].lower() in (video_exts - {'.strm'})
+                    ]
+                    best_local_path = min(video_candidates or relative_candidates, key=len)
+                elif local_root:
+                    shortest = min(local_candidates, key=len)
+                    # 如果最短的候选路径比原始路径短，说明成功剥离了 local_root
+                    if len(shortest) < len(absolute_path):
+                        best_local_path = shortest
 
             values = {
                 'fid': None,
@@ -366,8 +460,21 @@ def repair_p115_fingerprints_for_rows(
                 'size': _get_asset_size(asset),
             }
 
-            # 1) 走已有万能提取器 (仅在缺失 PC/SHA1 时调用)
-            if need_pc or need_sha1:
+            # 1) 优先从 p115_filesystem_cache 反查；外部/CD2 STRM 命中缓存时不需要访问 115。
+            cache_hit = False
+            cache_is_complete = False # ★ 新增：标记缓存是否完整
+            if P115CacheManager:
+                try:
+                    cache_row = _p115_fp_lookup_cache(P115CacheManager, values, local_candidates)
+                    if cache_row:
+                        cache_hit = True
+                        _merge_cache_row(cache_row, values)
+                        cache_is_complete = _p115_fp_cache_values_complete(values)
+                except Exception as e:
+                    logger.debug(f"  ➜ [{log_prefix}] 查询 p115_filesystem_cache 失败: {e}")
+
+            # 2) 缓存仍未补齐 PC/SHA1 时，再走已有万能提取器。
+            if (need_pc and not values.get('pc')) or (need_sha1 and not values.get('sha1')):
                 extractor = getattr(processor, '_extract_115_fingerprints', None) if processor else None
                 if callable(extractor):
                     for probe_path in [clean_path, strm_target]:
@@ -382,36 +489,15 @@ def repair_p115_fingerprints_for_rows(
                         except Exception as e:
                             logger.debug(f"  ➜ [{log_prefix}] 指纹提取器跳过异常路径: {probe_path} -> {e}")
 
-            # 2) 从 p115_filesystem_cache 反查
-            cache_hit = False
-            cache_is_complete = False # ★ 新增：标记缓存是否完整
-            if P115CacheManager:
-                try:
-                    cache_row = None
-                    if values.get('pc'):
-                        cache_row = P115CacheManager.get_file_cache_by_pickcode(values['pc'])
-                    if not cache_row and values.get('sha1'):
-                        cache_row = P115CacheManager.get_file_cache_by_sha1(values['sha1'])
-                    if not cache_row and values.get('fid'):
-                        cache_row = P115CacheManager.get_file_cache_by_id(values['fid'])
-
-                    if not cache_row:
-                        for local_candidate in local_candidates:
-                            cache_row = P115CacheManager.get_file_cache_by_local_path(local_candidate)
-                            if cache_row:
-                                break
-
-                    if cache_row:
-                        cache_hit = True
-                        _merge_cache_row(cache_row, values)
-                        
-                        # ★ 核心修改 2：检查缓存六芒星是否齐全
-                        if (values.get('fid') and values.get('parent_id') and 
-                            values.get('name') and values.get('sha1') and 
-                            values.get('pc') and values.get('size')):
-                            cache_is_complete = True
-                except Exception as e:
-                    logger.debug(f"  ➜ [{log_prefix}] 查询 p115_filesystem_cache 失败: {e}")
+                if P115CacheManager and not cache_is_complete:
+                    try:
+                        cache_row = _p115_fp_lookup_cache(P115CacheManager, values, local_candidates)
+                        if cache_row:
+                            cache_hit = True
+                            _merge_cache_row(cache_row, values)
+                            cache_is_complete = _p115_fp_cache_values_complete(values)
+                    except Exception as e:
+                        logger.debug(f"  ➜ [{log_prefix}] 查询 p115_filesystem_cache 失败: {e}")
 
             # 3) 仍然缺字段时，现场按 PC 计算 FID，再查 115 详情。
             # ★ 核心修改 3：只要缓存不完整，也触发 API 查询


### PR DESCRIPTION
## 背景

在挂载路径 STRM 场景下，用户可能已经由 CD2 或其他工具生成了 `.strm`，内容是类似 `/cd2/115open/Media/.../xxx.mkv` 的真实挂载路径。ETK 的“全量生成 STRM”仍需要补齐 `p115_filesystem_cache`，但不应覆盖这些外部 STRM，否则 Emby 会把文件当成新资源重新入库/提取媒体信息。

另外，当 115 远端目录已经删除而本地仍保留旧 cid 时，115 OpenAPI 可能返回 `state=true`，但 `path` 只包含根目录，同时 `data` 是无关文件。旧逻辑会继续处理这些无关结果，存在误生成/误关联风险。

## 修改内容

- 全量生成 STRM 在路径模式下遇到已存在的路径式 STRM 时跳过覆盖，但仍继续写入/更新 `p115_filesystem_cache`。
- 对 OpenAPI 兜底结果增加 path/cid 校验：返回路径不包含目标 cid 时视为远端目录删除或本地缓存过期，跳过该分类兜底同步，并阻止后续清理阶段误删。
- 指纹补齐 helper 支持从外部/CD2 STRM 内容剥离挂载前缀，反推出 `p115_filesystem_cache.local_path` 候选。
- 指纹补齐改为优先查本地缓存，缓存命中时不调用提取器/115 详情接口；缓存缺失或不完整时保留原有后续补齐链路。

## 验证

- 本地：`python -m py_compile tasks/p115.py tasks/p115_fingerprint_helpers.py`
- 本地：`git diff --check upstream/dev...HEAD`
- 本地离线模拟：CD2 STRM 内容 `/cd2/115open/Media/.../Sample.mp4` 可映射到 `p115_filesystem_cache.local_path`，缓存命中补齐 PC/SHA1，`api_fixed_assets=0`，extractor 调用次数为 0。
- Live 容器：热补丁到 `/app/tasks/p115.py`、`/app/tasks/p115_fingerprint_helpers.py`，恢复 `root:root 644` 后 `PYTHONPYCACHEPREFIX=/tmp/etk-pycache python3 -m py_compile ...` 通过。
- Live 容器：用已失效的 `盛唐奇案` cid 做单规则全量同步，Cookie 返回空后 OpenAPI 复查检测到 path 不含目标 cid，跳过分类，新增/更新 STRM 为 0。
- Live 容器：用现有 007 CD2 STRM 做 `update_db=False, allow_api_fetch=False` dry-run，命中本地缓存补齐 PC/SHA1，`api_fixed_assets=0`，extractor 调用次数为 0。
- Live 容器：验证后 007 和盛唐奇案样本 STRM 的 size/mtime/hash 均未变化，近 10 分钟无 405/流控日志，无残留手工 Python 进程。

## 备注

`git etk-pr-check` 在 linked worktree 中因本地 `.git-tools` 路径假设无法完整运行；已手动执行其核心检查项：PR diff 的 `git diff --check` 和变更 Python 文件的 `py_compile`。
