### PR TITLE
兼容 Jellyfin 反向代理、Webhook 和 STRM 扫库通知

### DIFF
--- a/handler/emby.py
+++ b/handler/emby.py
@@ -938,44 +938,51 @@ def _force_refresh_directory_tree(target_dir: str, base_url: str, api_key: str):
 def notify_emby_file_changes(file_paths: List[str], base_url: str, api_key: str, update_type: str = "Created") -> bool:
     """
     【极速轻量级刷新】
-    直接提取文件所在目录，向上寻根并触发 Emby 的局部精准扫描。
-    彻底抛弃 Emby 带有 90 秒延迟的 Updated 队列接口。
+    先通过 /Library/Media/Updated 通知媒体服务器具体文件变更；再触发父目录刷新作为补强。
+    Jellyfin 对新增 STRM 更依赖 Media Updated 事件，Emby 继续保留原来的目录精准扫描路径。
     """
-    if not file_paths: 
+    if not file_paths:
         return True
-        
+
     action_map = {
         "Created": "新增",
         "Modified": "修改",
         "Deleted": "删除"
     }
     action_zh = action_map.get(update_type, update_type)
-    
+
     try:
-        if str(update_type or "").lower() == "deleted":
-            api_url = f"{base_url.rstrip('/')}/Library/Media/Updated"
-            payload = {
-                "Updates": [
-                    {"Path": str(p), "UpdateType": "Deleted"}
-                    for p in file_paths
-                    if p
-                ]
-            }
-            if payload["Updates"]:
-                resp = emby_client.post(api_url, params={"api_key": api_key}, json=payload, timeout=10)
-                if resp.status_code not in (200, 204):
-                    logger.debug(f"  ➜ [极速通知] 删除事件通知返回 HTTP {resp.status_code}: {resp.text[:200]}")
+        normalized_update_type = str(update_type or "Created").strip() or "Created"
+        normalized_update_type = normalized_update_type[:1].upper() + normalized_update_type[1:].lower()
+        if normalized_update_type not in {"Created", "Modified", "Deleted"}:
+            normalized_update_type = "Modified"
+
+        api_url = f"{base_url.rstrip('/')}/Library/Media/Updated"
+        payload = {
+            "Updates": [
+                {"Path": str(p), "UpdateType": normalized_update_type}
+                for p in file_paths
+                if p
+            ]
+        }
+        media_updated_ok = True
+        if payload["Updates"]:
+            resp = emby_client.post(api_url, params={"api_key": api_key}, json=payload, timeout=10)
+            media_updated_ok = resp.status_code in (200, 204)
+            if media_updated_ok:
+                logger.debug(f"  ➜ [极速通知] 已发送 {len(payload['Updates'])} 个文件{action_zh}事件到媒体库更新接口。")
+            else:
+                logger.debug(f"  ➜ [极速通知] 媒体库更新接口返回 HTTP {resp.status_code}: {resp.text[:200]}")
 
         # 直接提取所有文件所在的目录，去重 (防止批量入库时重复刷新同一个父目录)
         dirs_to_refresh = set(os.path.dirname(p) for p in file_paths if p)
 
-        # logger.info(f"  ➜ 收到 {len(file_paths)} 个文件{action_zh}请求，准备对 {len(dirs_to_refresh)} 个父目录触发精准扫描...")
-
-        # 直接拿鞭子抽，让 Emby 扫目录
+        # Jellyfin 对 STRM 新文件更依赖 /Library/Media/Updated；目录刷新作为 Emby/Jellyfin 的补强与回退。
+        refresh_ok = True
         for d in dirs_to_refresh:
-            _force_refresh_directory_tree(d, base_url, api_key)
-            
-        return True
+            refresh_ok = _force_refresh_directory_tree(d, base_url, api_key) and refresh_ok
+
+        return media_updated_ok or refresh_ok
     except Exception as e:
         logger.error(f"  ➜ [极速通知] 触发扫描失败: {e}")
         return False

--- a/reverse_proxy.py
+++ b/reverse_proxy.py
@@ -398,8 +398,54 @@ def from_mimicked_id(mimicked_id): return -(int(mimicked_id)) - MIMICKED_ID_BASE
 def is_mimicked_id(item_id):
     try: return isinstance(item_id, str) and item_id.startswith('-')
     except: return False
-MIMICKED_ITEMS_RE = re.compile(r'/emby/Users/([^/]+)/Items/(-(\d+))')
-MIMICKED_ITEM_DETAILS_RE = re.compile(r'emby/Users/([^/]+)/Items/(-(\d+))$')
+MIMICKED_ITEMS_RE = re.compile(r'/(?:emby/)?Users/([^/]+)/Items/(-(\d+))', re.IGNORECASE)
+MIMICKED_ITEM_DETAILS_RE = re.compile(r'(?:emby/)?Users/([^/]+)/Items/(-(\d+))$', re.IGNORECASE)
+
+
+def _server_api_url(base_url, path):
+    return f"{base_url.rstrip('/')}/{str(path).lstrip('/')}"
+
+
+def _strip_emby_api_prefix(path):
+    normalized = str(path or '').lstrip('/')
+    return normalized[5:] if normalized.lower().startswith('emby/') else normalized
+
+
+def _proxy_path_equals(path, expected):
+    return _strip_emby_api_prefix(path).strip('/').lower() == str(expected).strip('/').lower()
+
+
+def _proxy_path_startswith(path, expected):
+    return _strip_emby_api_prefix(path).lower().startswith(str(expected).lstrip('/').lower())
+
+
+def _match_user_views_path(path):
+    return re.match(r'^Users/([^/]+)/Views$', _strip_emby_api_prefix(path), re.IGNORECASE)
+
+
+def _match_user_items_path(path):
+    return re.match(r'^Users/([^/]+)/Items$', _strip_emby_api_prefix(path), re.IGNORECASE)
+
+
+def _match_user_latest_path(path):
+    return re.match(r'^Users/([^/]+)/Items/Latest$', _strip_emby_api_prefix(path), re.IGNORECASE)
+
+
+def _get_param_any(params, *names, default=None):
+    for name in names:
+        value = params.get(name)
+        if value is not None:
+            return value
+
+    wanted = {str(name).lower() for name in names}
+    try:
+        keys = params.keys()
+    except AttributeError:
+        keys = []
+    for key in keys:
+        if str(key).lower() in wanted:
+            return params.get(key)
+    return default
 
 def _get_real_emby_url_and_key():
     base_url = config_manager.APP_CONFIG.get("emby_server_url", "").rstrip('/')
@@ -449,7 +495,9 @@ def _current_play_concurrency_device_id():
         device_id = (
             request.args.get('DeviceId')
             or request.args.get('X-Emby-Device-Id')
+            or request.args.get('X-MediaBrowser-Device-Id')
             or request.headers.get('X-Emby-Device-Id')
+            or request.headers.get('X-MediaBrowser-Device-Id')
             or _extract_emby_auth_header_value('DeviceId')
             or ''
         )
@@ -462,8 +510,8 @@ def _current_play_concurrency_client_signature():
     try:
         parts = [
             request.remote_addr or "",
-            request.args.get('X-Emby-Client') or request.headers.get('X-Emby-Client') or _extract_emby_auth_header_value('Client'),
-            request.headers.get('X-Emby-Device-Name') or _extract_emby_auth_header_value('Device'),
+            request.args.get('X-Emby-Client') or request.args.get('X-MediaBrowser-Client') or request.headers.get('X-Emby-Client') or request.headers.get('X-MediaBrowser-Client') or _extract_emby_auth_header_value('Client'),
+            request.headers.get('X-Emby-Device-Name') or request.headers.get('X-MediaBrowser-Device-Name') or _extract_emby_auth_header_value('Device'),
             request.headers.get('User-Agent') or "",
         ]
     except RuntimeError:
@@ -570,8 +618,8 @@ def _request_context_keys(full_path="", play_session_id=""):
 
     token = _extract_emby_token_from_request()
     add("token", token)
-    add("device", request.args.get('DeviceId') or request.args.get('X-Emby-Device-Id') or request.headers.get('X-Emby-Device-Id') or _extract_emby_auth_header_value('DeviceId'))
-    add("play_session", play_session_id or request.args.get('PlaySessionId'))
+    add("device", request.args.get('DeviceId') or request.args.get('X-Emby-Device-Id') or request.args.get('X-MediaBrowser-Device-Id') or request.headers.get('X-Emby-Device-Id') or request.headers.get('X-MediaBrowser-Device-Id') or _extract_emby_auth_header_value('DeviceId'))
+    add("play_session", play_session_id or _get_param_any(request.args, 'PlaySessionId', 'playSessionId'))
 
     return list(dict.fromkeys(keys))
 
@@ -684,12 +732,7 @@ def _lookup_cached_request_user(full_path="", play_session_id=""):
 
 
 def _extract_user_id_from_request_path_or_args(full_path=""):
-    user_id = (
-        request.args.get('UserId')
-        or request.args.get('userId')
-        or request.args.get('user_id')
-        or ''
-    )
+    user_id = _get_param_any(request.args, 'UserId', 'userId', 'user_id', default='')
     if user_id:
         return str(user_id).strip()
     user_id_match = re.search(r'/Users/([^/]+)/', full_path or '', re.IGNORECASE)
@@ -710,8 +753,8 @@ def _resolve_request_user_id(base_url, api_key, full_path="", play_session_id=""
     if token and token != api_key:
         try:
             resp = requests.get(
-                f"{base_url.rstrip('/')}/emby/Users/Me",
-                headers={"X-Emby-Token": token, "Accept": "application/json"},
+                _server_api_url(base_url, "Users/Me"),
+                headers={"X-Emby-Token": token, "X-MediaBrowser-Token": token, "Accept": "application/json"},
                 timeout=5,
             )
             if resp.status_code == 200:
@@ -724,7 +767,7 @@ def _resolve_request_user_id(base_url, api_key, full_path="", play_session_id=""
 
     if play_session_id:
         try:
-            resp = requests.get(f"{base_url.rstrip('/')}/emby/Sessions", params={"api_key": api_key}, timeout=5)
+            resp = requests.get(_server_api_url(base_url, "Sessions"), params={"api_key": api_key}, timeout=5)
             if resp.status_code == 200:
                 for item in resp.json() or []:
                     item_play_state = item.get('PlayState') or {}
@@ -933,10 +976,19 @@ def _fetch_items_in_chunks(base_url, api_key, user_id, item_ids, fields):
     
     # 适当增大分块大小以减少请求数
     id_chunks = list(chunk_list(unique_ids, 200))
-    target_url = f"{base_url}/emby/Users/{user_id}/Items"
+    target_url = _server_api_url(base_url, "Items")
     
     def fetch_chunk(chunk):
-        params = {'api_key': api_key, 'Ids': ",".join(chunk), 'Fields': fields}
+        ids = ",".join(chunk)
+        params = {
+            'api_key': api_key,
+            'Ids': ids,
+            'ids': ids,
+            'Fields': fields,
+            'fields': fields,
+            'UserId': user_id,
+            'userId': user_id,
+        }
         try:
             resp = requests.get(target_url, params=params, timeout=20)
             resp.raise_for_status()
@@ -971,11 +1023,24 @@ def _fetch_sorted_items_via_emby_proxy(user_id, item_ids, sort_by, sort_order, l
         if estimated_ids_length < URL_LENGTH_THRESHOLD:
             # --- 路径 A: ID列表较短，直接请求 Emby (最快，且自动处理权限) ---
             logger.trace(f"  ➜ [Emby 代理排序] ID列表较短 ({len(item_ids)}个)，使用 GET 方法。")
-            target_url = f"{base_url}/emby/Users/{user_id}/Items"
+            target_url = _server_api_url(base_url, "Items")
+            ids = ",".join(item_ids)
             emby_params = {
-                'api_key': api_key, 'Ids': ",".join(item_ids), 'Fields': fields,
-                'SortBy': sort_by, 'SortOrder': sort_order,
-                'StartIndex': offset, 'Limit': limit,
+                'api_key': api_key,
+                'Ids': ids,
+                'ids': ids,
+                'Fields': fields,
+                'fields': fields,
+                'UserId': user_id,
+                'userId': user_id,
+                'SortBy': sort_by,
+                'sortBy': sort_by,
+                'SortOrder': sort_order,
+                'sortOrder': sort_order,
+                'StartIndex': offset,
+                'startIndex': offset,
+                'Limit': limit,
+                'limit': limit,
             }
             resp = requests.get(target_url, params=emby_params, timeout=25)
             resp.raise_for_status()
@@ -1034,10 +1099,10 @@ def handle_get_views():
         return "Proxy is not ready", 503
 
     try:
-        user_id_match = re.search(r'/emby/Users/([^/]+)/Views', request.path)
-        if not user_id_match:
+        user_id_match = _match_user_views_path(request.path)
+        user_id = user_id_match.group(1) if user_id_match else _get_param_any(request.args, 'userId', 'UserId', 'user_id', default='')
+        if not user_id:
             return "Could not determine user from request path", 400
-        user_id = user_id_match.group(1)
         client_signature = _current_play_concurrency_client_signature()
 
         if _is_official_ios_client(client_signature):
@@ -1245,6 +1310,7 @@ def handle_mimicked_library_metadata_endpoint(path, mimicked_id, params):
         
         new_params = params.copy()
         new_params['ParentId'] = real_emby_collection_id
+        new_params['parentId'] = real_emby_collection_id
         new_params['api_key'] = api_key
         
         resp = requests.get(target_url, headers=headers, params=new_params, timeout=15)
@@ -1276,16 +1342,16 @@ def handle_get_mimicked_library_items(user_id, mimicked_id, params):
         collection_type = collection_info.get('type')
         
         # 2. 获取分页和排序参数 (变量定义必须在此处)
-        emby_limit = int(params.get('Limit', 50))
-        offset = int(params.get('StartIndex', 0))
+        emby_limit = int(_get_param_any(params, 'Limit', 'limit', default=50))
+        offset = int(_get_param_any(params, 'StartIndex', 'startIndex', default=0))
         
         defined_limit = definition.get('limit')
         if defined_limit:
             defined_limit = int(defined_limit)
         
         # --- 排序优先级逻辑 ---
-        req_sort_by = params.get('SortBy')
-        req_sort_order = params.get('SortOrder')
+        req_sort_by = _get_param_any(params, 'SortBy', 'sortBy')
+        req_sort_order = _get_param_any(params, 'SortOrder', 'sortOrder')
         
         defined_sort_by = definition.get('default_sort_by')
         defined_sort_order = definition.get('default_sort_order')
@@ -1566,9 +1632,9 @@ def handle_get_latest_items(user_id, params):
     """
     try:
         base_url, api_key = _get_real_emby_url_and_key()
-        virtual_library_id = params.get('ParentId') or params.get('customViewId')
-        limit = int(params.get('Limit', 20))
-        fields = params.get('Fields', "PrimaryImageAspectRatio,BasicSyncInfo,DateCreated,UserData")
+        virtual_library_id = _get_param_any(params, 'ParentId', 'parentId', 'customViewId', default='')
+        limit = int(_get_param_any(params, 'Limit', 'limit', default=20))
+        fields = _get_param_any(params, 'Fields', 'fields', default="PrimaryImageAspectRatio,BasicSyncInfo,DateCreated,UserData")
 
         # --- 辅助函数：获取合集的过滤 ID ---
         def get_collection_filter_ids(coll_data):
@@ -1761,13 +1827,13 @@ def proxy_all(path):
         full_path = f'/{path}'
         observed_user_id = _extract_user_id_from_request_path_or_args(full_path)
         if observed_user_id:
-            _cache_request_user_context(observed_user_id, full_path, request.args.get('PlaySessionId', ''))
+            _cache_request_user_context(observed_user_id, full_path, _get_param_any(request.args, 'PlaySessionId', 'playSessionId', default=''))
         full_path_lower = full_path.lower()
         if request.method in ('POST', 'DELETE') and '/sessions/playing/stopped' in full_path_lower:
             base_url, api_key = _get_real_emby_url_and_key()
             payload = request.get_json(silent=True) or {}
-            play_session_id = request.args.get('PlaySessionId', '') or payload.get('PlaySessionId', '')
-            item_id = request.args.get('ItemId', '') or payload.get('ItemId', '')
+            play_session_id = _get_param_any(request.args, 'PlaySessionId', 'playSessionId', default='') or payload.get('PlaySessionId', '') or payload.get('playSessionId', '')
+            item_id = _get_param_any(request.args, 'ItemId', 'itemId', default='') or payload.get('ItemId', '') or payload.get('itemId', '')
             current_user_id = _resolve_request_user_id(base_url, api_key, full_path, play_session_id)
             _clear_play_concurrency_session(current_user_id, item_id=item_id, play_session_id=play_session_id)
 
@@ -1777,9 +1843,9 @@ def proxy_all(path):
             and full_path_lower.endswith('/playbackinfo')
         ):
             base_url, api_key = _get_real_emby_url_and_key()
-            item_match = re.search(r'/items/(\d+)/playbackinfo$', full_path_lower)
+            item_match = re.search(r'/items/([^/?]+)/playbackinfo$', full_path, re.IGNORECASE)
             item_id = item_match.group(1) if item_match else ''
-            play_session_id = request.args.get('PlaySessionId', '')
+            play_session_id = _get_param_any(request.args, 'PlaySessionId', 'playSessionId', default='')
             current_user_id = _resolve_request_user_id(base_url, api_key, full_path, play_session_id)
 
             target_url = f"{base_url}/{path.lstrip('/')}"
@@ -1825,16 +1891,16 @@ def proxy_all(path):
         if ('/videos/' in full_path_lower and ('/stream' in full_path_lower or '/original' in full_path_lower)) or ('/items/' in full_path_lower and '/download' in full_path_lower):
             # 检测浏览器客户端
             user_agent = request.headers.get('User-Agent', '').lower()
-            client_name = request.headers.get('X-Emby-Client', '').lower()
+            client_name = (request.headers.get('X-Emby-Client') or request.headers.get('X-MediaBrowser-Client') or '').lower()
             is_browser = 'mozilla' in user_agent or 'chrome' in user_agent or 'safari' in user_agent
             native_clients = ['androidtv', 'infuse', 'emby for ios', 'emby for android', 'emby theater', 'senplayer', 'applecoremedia']
             if any(nc in client_name for nc in native_clients) or 'infuse' in user_agent or 'dalvik' in user_agent or 'applecoremedia' in user_agent:
                 is_browser = False
             
             # 客户端处理逻辑
-            match = re.search(r'/(?:videos|items)/(\d+)/', full_path_lower)
+            match = re.search(r'/(?:videos|items)/([^/?]+)/', full_path, re.IGNORECASE)
             item_id = match.group(1) if match else ''
-            play_session_id = request.args.get('PlaySessionId', '')
+            play_session_id = _get_param_any(request.args, 'PlaySessionId', 'playSessionId', default='')
             
             pick_code = None
             virtual_play_info = None
@@ -1859,12 +1925,15 @@ def proxy_all(path):
 
                 if not data:
                     if not pick_code:
-                        playback_info_url = f"{base_url}/emby/Items/{item_id}/PlaybackInfo"
+                        playback_info_url = _server_api_url(base_url, f"Items/{item_id}/PlaybackInfo")
                         params = {
                             'api_key': api_key,
                             'UserId': current_user_id,
+                            'userId': current_user_id,
                             'MaxStreamingBitrate': 140000000,
+                            'maxStreamingBitrate': 140000000,
                             'PlaySessionId': play_session_id,
+                            'playSessionId': play_session_id,
                         }
                         
                         forward_headers = {k: v for k, v in request.headers if k.lower() not in ['host', 'accept-encoding']}
@@ -1886,8 +1955,8 @@ def proxy_all(path):
             if virtual_play_info:
                 player_ua = request.headers.get('User-Agent', 'Mozilla/5.0')
                 play_client_key = "|".join([
-                    request.args.get('DeviceId') or request.args.get('X-Emby-Device-Id') or request.headers.get('X-Emby-Device-Id') or request.remote_addr or "",
-                    request.headers.get('X-Emby-Client') or "",
+                    request.args.get('DeviceId') or request.args.get('X-Emby-Device-Id') or request.args.get('X-MediaBrowser-Device-Id') or request.headers.get('X-Emby-Device-Id') or request.headers.get('X-MediaBrowser-Device-Id') or request.remote_addr or "",
+                    request.headers.get('X-Emby-Client') or request.headers.get('X-MediaBrowser-Client') or "",
                     request.headers.get('User-Agent') or "",
                 ])
                 try:
@@ -1911,8 +1980,8 @@ def proxy_all(path):
             if pick_code:
                 player_ua = request.headers.get('User-Agent', 'Mozilla/5.0')
                 play_client_key = "|".join([
-                    request.args.get('DeviceId') or request.args.get('X-Emby-Device-Id') or request.headers.get('X-Emby-Device-Id') or request.remote_addr or "",
-                    request.headers.get('X-Emby-Client') or "",
+                    request.args.get('DeviceId') or request.args.get('X-Emby-Device-Id') or request.args.get('X-MediaBrowser-Device-Id') or request.headers.get('X-Emby-Device-Id') or request.headers.get('X-MediaBrowser-Device-Id') or request.remote_addr or "",
+                    request.headers.get('X-Emby-Client') or request.headers.get('X-MediaBrowser-Client') or "",
                     request.headers.get('User-Agent') or "",
                 ])
 
@@ -1925,7 +1994,7 @@ def proxy_all(path):
                     "user_id": current_user_id,
                     "source": 'reverse_proxy',
                     "client_key": play_client_key,
-                    "client_name": request.headers.get('X-Emby-Client') or request.headers.get('User-Agent') or "",
+                    "client_name": request.headers.get('X-Emby-Client') or request.headers.get('X-MediaBrowser-Client') or request.headers.get('User-Agent') or "",
                 }
                 use_copy_play = False if play_pool_enabled else is_copy_play_enabled()
 
@@ -2040,8 +2109,9 @@ def proxy_all(path):
             return Response(resp.iter_content(chunk_size=8192), resp.status_code, response_headers)
         
         # --- 4. 拦截 A: 虚拟项目海报图片 ---
-        if path.startswith('emby/Items/') and '/Images/Primary' in path:
-            item_id = path.split('/')[2]
+        if _proxy_path_startswith(path, 'Items/') and '/Images/Primary' in path:
+            item_match = re.search(r'^Items/([^/]+)/Images/Primary', _strip_emby_api_prefix(path), re.IGNORECASE)
+            item_id = item_match.group(1) if item_match else ''
             if is_missing_item_id(item_id):
                 combined_id = parse_missing_item_id(item_id)
                 real_tmdb_id = combined_id.split('_S_')[0] if '_S_' in combined_id else combined_id
@@ -2062,40 +2132,43 @@ def proxy_all(path):
                     return resp
 
         # --- 拦截 B: 视图列表 (Views) ---
-        if path.endswith('/Views') and path.startswith('emby/Users/'):
+        if _match_user_views_path(path) or _proxy_path_equals(path, 'UserViews'):
             return handle_get_views()
 
         # --- 拦截 C: 最新项目 (Latest) ---
-        if path.endswith('/Items/Latest'):
-            user_id_match = re.search(r'/emby/Users/([^/]+)/', full_path)
-            if user_id_match:
-                return handle_get_latest_items(user_id_match.group(1), request.args)
+        if _match_user_latest_path(path) or _proxy_path_equals(path, 'Items/Latest'):
+            user_id_match = _match_user_latest_path(path)
+            user_id = user_id_match.group(1) if user_id_match else _get_param_any(request.args, 'UserId', 'userId', 'user_id', default='')
+            if user_id:
+                return handle_get_latest_items(user_id, request.args)
 
         # --- 拦截 D: 虚拟库详情 (增强版拦截) ---
         details_match = re.search(r'/Items/(-(\d+))(?:$|\?)', full_path)
         if details_match and '/Images/' not in full_path and '/PlaybackInfo' not in full_path:
             mimicked_id = details_match.group(1)
             # 尝试从路径或参数获取 user_id
-            user_id_match = re.search(r'/Users/([^/]+)/', full_path)
-            user_id = user_id_match.group(1) if user_id_match else request.args.get('UserId')
+            user_id_match = re.search(r'/(?:emby/)?Users/([^/]+)/', full_path, re.IGNORECASE)
+            user_id = user_id_match.group(1) if user_id_match else _get_param_any(request.args, 'UserId', 'userId', 'user_id', default='')
             return handle_get_mimicked_library_details(user_id, mimicked_id)
 
         # --- 拦截 E: 虚拟库图片 ---
-        if path.startswith('emby/Items/') and '/Images/' in path:
-            item_id = path.split('/')[2]
+        if _proxy_path_startswith(path, 'Items/') and '/Images/' in path:
+            item_match = re.search(r'^Items/([^/]+)/Images/', _strip_emby_api_prefix(path), re.IGNORECASE)
+            item_id = item_match.group(1) if item_match else ''
             if is_mimicked_id(item_id):
                 return handle_get_mimicked_library_image(path)
         
         # --- 拦截 F: 虚拟库内容浏览 (Items) ---
         # 修复 iOS 传参大小写问题 (有时传 ParentId，有时传 parentId)
-        parent_id = request.args.get("ParentId") or request.args.get("parentId")
+        parent_id = _get_param_any(request.args, "ParentId", "parentId")
         
         if parent_id and is_mimicked_id(parent_id):
             # 1. 处理核心的内容列表请求 (严格匹配结尾，防止误伤 Filters)
-            user_id_match = re.search(r'emby/Users/([^/]+)/Items$', path)
-            if user_id_match:
-                user_id = user_id_match.group(1)
-                return handle_get_mimicked_library_items(user_id, parent_id, request.args)
+            user_id_match = _match_user_items_path(path)
+            if user_id_match or _proxy_path_equals(path, 'Items'):
+                user_id = user_id_match.group(1) if user_id_match else _get_param_any(request.args, 'UserId', 'userId', 'user_id', default='')
+                if user_id:
+                    return handle_get_mimicked_library_items(user_id, parent_id, request.args)
 
             # 2. 处理所有其他带有虚拟 ParentId 的请求 (如 /Filters, /Genres 等)
             return handle_mimicked_library_metadata_endpoint(path, parent_id, request.args)

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -61,6 +61,156 @@ UPDATE_DEBOUNCE_TIME = 15
 MP_BATCH_QUEUE = {}
 MP_BATCH_LOCK = threading.Lock()
 
+JELLYFIN_WEBHOOK_EVENT_MAP = {
+    "ItemAdded": "item.add",
+    "ItemUpdated": "metadata.update",
+    "ItemMetadataUpdated": "metadata.update",
+    "ItemImageUpdated": "image.update",
+    "ItemDeleted": "deep.delete",
+    "ItemRemoved": "deep.delete",
+    "PlaybackStart": "playback.start",
+    "PlaybackStop": "playback.stop",
+    "PlaybackProgress": "playback.progress",
+    "UserDataSaved": "item.rate",
+    "UserUpdated": "user.policyupdated",
+}
+
+
+def _pick_first(source, *keys):
+    if not isinstance(source, dict):
+        return None
+    for key in keys:
+        if key in source and source.get(key) not in (None, ""):
+            return source.get(key)
+    wanted = {str(key).lower() for key in keys}
+    for key, value in source.items():
+        if str(key).lower() in wanted and value not in (None, ""):
+            return value
+    return None
+
+
+def _coerce_bool(value):
+    if isinstance(value, bool):
+        return value
+    if value is None or value == "":
+        return None
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes", "y", "on"}:
+        return True
+    if text in {"false", "0", "no", "n", "off"}:
+        return False
+    return None
+
+
+def _normalize_jellyfin_webhook_payload(data):
+    if not isinstance(data, dict):
+        return data
+    if data.get("Event"):
+        return data
+
+    notification_type = _pick_first(data, "NotificationType", "notificationType", "Type")
+    if not notification_type:
+        return data
+
+    event_type = JELLYFIN_WEBHOOK_EVENT_MAP.get(str(notification_type))
+    if not event_type:
+        return data
+
+    normalized = dict(data)
+    item = dict(normalized.get("Item") or {})
+    user = dict(normalized.get("User") or {})
+    playback = dict(normalized.get("PlaybackInfo") or {})
+
+    item_id = _pick_first(data, "ItemId", "itemId", "Id", "id")
+    item_type = _pick_first(data, "ItemType", "itemType", "BaseItemKind")
+    item_name = _pick_first(data, "Name", "ItemName", "itemName")
+    series_id = _pick_first(data, "SeriesId", "seriesId")
+    series_name = _pick_first(data, "SeriesName", "seriesName")
+
+    if item_id is not None:
+        item.setdefault("Id", str(item_id))
+    if item_type is not None:
+        item.setdefault("Type", str(item_type))
+    if item_name is not None:
+        item.setdefault("Name", str(item_name))
+    if series_id is not None:
+        item.setdefault("SeriesId", str(series_id))
+    if series_name is not None:
+        item.setdefault("SeriesName", str(series_name))
+
+    for flat_key, item_key in (
+        ("Path", "Path"),
+        ("MediaSourceId", "MediaSourceId"),
+        ("RunTimeTicks", "RunTimeTicks"),
+        ("Overview", "Overview"),
+        ("Year", "ProductionYear"),
+    ):
+        value = _pick_first(data, flat_key, flat_key[:1].lower() + flat_key[1:])
+        if value is not None:
+            item.setdefault(item_key, value)
+
+    provider_ids = dict(item.get("ProviderIds") or {})
+    for source_key, provider_key in (
+        ("Provider_tmdb", "Tmdb"),
+        ("Provider_imdb", "Imdb"),
+        ("Provider_tvdb", "Tvdb"),
+    ):
+        value = _pick_first(data, source_key, source_key.lower(), source_key.upper())
+        if value is not None:
+            provider_ids.setdefault(provider_key, str(value))
+    if provider_ids:
+        item["ProviderIds"] = provider_ids
+
+    user_id = _pick_first(data, "UserId", "userId")
+    user_name = _pick_first(data, "Username", "NotificationUsername", "UserName", "userName")
+    if user_id is not None:
+        user.setdefault("Id", str(user_id))
+    if user_name is not None:
+        user.setdefault("Name", str(user_name))
+
+    user_data = dict(item.get("UserData") or {})
+    favorite = _coerce_bool(_pick_first(data, "Favorite", "IsFavorite", "favorite", "isFavorite"))
+    played = _coerce_bool(_pick_first(data, "Played", "played"))
+    likes = _coerce_bool(_pick_first(data, "Likes", "likes"))
+    rating = _pick_first(data, "Rating", "rating")
+    play_count = _pick_first(data, "PlayCount", "playCount")
+    if favorite is not None:
+        user_data.setdefault("IsFavorite", favorite)
+    if played is not None:
+        user_data.setdefault("Played", played)
+    if likes is not None:
+        user_data.setdefault("Likes", likes)
+    if rating is not None:
+        user_data.setdefault("Rating", rating)
+    if play_count is not None:
+        user_data.setdefault("PlayCount", play_count)
+
+    position_ticks = _pick_first(data, "PlaybackPositionTicks", "PositionTicks", "playbackPositionTicks", "positionTicks")
+    if position_ticks is not None:
+        playback.setdefault("PositionTicks", position_ticks)
+        user_data.setdefault("PlaybackPositionTicks", position_ticks)
+    played_to_completion = _coerce_bool(_pick_first(data, "PlayedToCompletion", "playedToCompletion"))
+    if played_to_completion is not None:
+        playback.setdefault("PlayedToCompletion", played_to_completion)
+    is_paused = _coerce_bool(_pick_first(data, "IsPaused", "isPaused"))
+    if is_paused is not None:
+        playback.setdefault("IsPaused", is_paused)
+    play_method = _pick_first(data, "PlayMethod", "playMethod")
+    if play_method is not None:
+        playback.setdefault("PlayMethod", play_method)
+
+    if user_data:
+        item["UserData"] = user_data
+    if item:
+        normalized["Item"] = item
+    if user:
+        normalized["User"] = user
+    if playback:
+        normalized["PlaybackInfo"] = playback
+    normalized["Event"] = event_type
+    normalized.setdefault("Source", "Jellyfin")
+    return normalized
+
 
 def _should_skip_non_etk_strm_webhook(item_type: str, item_name: str, item_path: str) -> bool:
     """Webhook 只处理 ETK 自己生成的 STRM，避免第三方 STRM 进入整理/刮削链路。"""
@@ -1501,9 +1651,10 @@ def _wait_for_stream_data_and_enqueue(item_id, item_name, item_type, file_path=N
 
 # --- Webhook 路由 ---
 @webhook_bp.route('/webhook/emby', methods=['POST'])
+@webhook_bp.route('/webhook/jellyfin', methods=['POST'])
 @extensions.processor_ready_required
 def emby_webhook():
-    data = request.json
+    data = _normalize_jellyfin_webhook_payload(request.json)
     # ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
     # ★★★            魔法日志 - START            ★★★
     # ★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★★
@@ -1668,7 +1819,7 @@ def emby_webhook():
     USER_DATA_EVENTS = [
         "item.markfavorite", "item.unmarkfavorite",
         "item.markplayed", "item.markunplayed",
-        "playback.start", "playback.pause", "playback.stop",
+        "playback.start", "playback.pause", "playback.stop", "playback.progress",
         "item.rate"
     ]
 
@@ -1764,7 +1915,7 @@ def emby_webhook():
                     update_data['playback_position_ticks'] = 0
                     update_data['last_played_date'] = datetime.now(timezone.utc)
 
-        elif event_type in ["playback.start", "playback.pause", "playback.stop"]:
+        elif event_type in ["playback.start", "playback.pause", "playback.stop", "playback.progress"]:
             playback_info = data.get("PlaybackInfo", {})
             if playback_info:
                 position_ticks = playback_info.get('PositionTicks')


### PR DESCRIPTION
﻿## 变更内容

- 兼容 Jellyfin 客户端常用反代路径与查询参数：
  - `/UserViews?userId=...`
  - `/Items?parentId=...&userId=...`
  - `/Items/Latest?parentId=...&userId=...`
  - 支持不带 `/emby` 前缀的虚拟库路径、Jellyfin 小写参数，以及 UUID/string 类型的 ItemId
- 兼容 Jellyfin Webhook 插件：
  - 新增 `/webhook/jellyfin` 入口，保留原 `/webhook/emby`
  - 将 `NotificationType`、`ItemId`、`ItemType`、`UserId` 等 Jellyfin 平铺字段归一化为现有 Emby Webhook 结构
  - 覆盖入库、元数据/图片更新、删除、播放状态、用户数据更新等事件
- 修复生成 STRM 后 Jellyfin 不触发扫库的问题：
  - `notify_emby_file_changes` 现在会优先发送 `/Library/Media/Updated`
  - 为 Created/Modified/Deleted 写入 `UpdateType`
  - 保留原父目录刷新逻辑作为补强/回退

## 验证

- `uv run python -m py_compile handler/emby.py routes/webhook.py reverse_proxy.py`
- `git diff --check`
